### PR TITLE
Fix namespace mismatch

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,7 +1,7 @@
 ﻿<Application x:Class="DamnSimpleFileManager.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:FileManager"
+             xmlns:local="clr-namespace:DamnSimpleFileManager"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
 

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -2,7 +2,7 @@
 using System.Data;
 using System.Windows;
 
-namespace FileManager
+namespace DamnSimpleFileManager
 {
     /// <summary>
     /// Interaction logic for App.xaml


### PR DESCRIPTION
## Summary
- fix mismatched namespaces between `App.xaml` and `App.xaml.cs`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436f3a72d88322a23c07010044a912