### PR TITLE
Add basic operations and refactor panes

### DIFF
--- a/FilePane.cs
+++ b/FilePane.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows.Controls;
+
+namespace DamnSimpleFileManager
+{
+    internal class FilePane
+    {
+        public ListView List { get; }
+        public TextBlock PathText { get; }
+        public ComboBox DriveSelector { get; }
+        public Button BackButton { get; }
+
+        public DirectoryInfo CurrentDir { get; private set; } = null!;
+        private readonly Stack<DirectoryInfo> history = new();
+
+        public FilePane(ListView list, TextBlock pathText, ComboBox driveSelector, Button backButton)
+        {
+            List = list;
+            PathText = pathText;
+            DriveSelector = driveSelector;
+            BackButton = backButton;
+        }
+
+        public void PopulateDrives()
+        {
+            DriveSelector.Items.Clear();
+            foreach (var drive in DriveInfo.GetDrives())
+            {
+                if (drive.IsReady)
+                {
+                    DriveSelector.Items.Add(drive.Name);
+                }
+            }
+
+            if (DriveSelector.Items.Count > 0)
+            {
+                DriveSelector.SelectedIndex = 0;
+                CurrentDir = new DirectoryInfo(DriveSelector.SelectedItem!.ToString()!);
+                LoadDirectory(CurrentDir);
+            }
+
+            UpdateBackButton();
+        }
+
+        public void SetDrive(string path)
+        {
+            CurrentDir = new DirectoryInfo(path);
+            history.Clear();
+            LoadDirectory(CurrentDir);
+            UpdateBackButton();
+        }
+
+        public void LoadDirectory(DirectoryInfo dir)
+        {
+            var items = new ObservableCollection<FileSystemInfo>();
+            foreach (var d in dir.GetDirectories()) items.Add(d);
+            foreach (var f in dir.GetFiles()) items.Add(f);
+            List.ItemsSource = items;
+            PathText.Text = dir.FullName;
+        }
+
+        public void NavigateInto(DirectoryInfo dir)
+        {
+            history.Push(CurrentDir);
+            CurrentDir = dir;
+            LoadDirectory(CurrentDir);
+            UpdateBackButton();
+        }
+
+        public void NavigateBack()
+        {
+            if (history.Count > 0)
+            {
+                CurrentDir = history.Pop();
+                LoadDirectory(CurrentDir);
+                UpdateBackButton();
+            }
+        }
+
+        public void UpdateBackButton()
+        {
+            BackButton.IsEnabled = history.Count > 0;
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -10,6 +10,8 @@
             <RowDefinition Height="Auto"/>
             <!-- Назад -->
             <RowDefinition Height="Auto"/>
+            <!-- Операции -->
+            <RowDefinition Height="Auto"/>
             <!-- Пути -->
             <RowDefinition Height="*"/>
             <!-- Списки -->
@@ -41,8 +43,24 @@
                     Click="RightBack_Click" HorizontalAlignment="Right" Margin="5"/>
         </Grid>
 
-        <!-- Текущие пути -->
+        <!-- Операции -->
         <Grid Grid.Row="2" Margin="5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Button x:Name="CreateFolderButton" Grid.Column="1" Content="Создать папку" Width="100" Height="30" Click="CreateFolder_Click"/>
+            <Button x:Name="CreateFileButton" Grid.Column="2" Content="Создать файл" Width="100" Height="30" Margin="5,0" Click="CreateFile_Click"/>
+            <Button x:Name="CopyButton" Grid.Column="3" Content="Копировать" Width="100" Height="30" Margin="5,0" Click="Copy_Click"/>
+            <Button x:Name="MoveButton" Grid.Column="4" Content="Переместить" Width="100" Height="30" Margin="5,0" Click="Move_Click"/>
+        </Grid>
+
+        <!-- Текущие пути -->
+        <Grid Grid.Row="3" Margin="5">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
@@ -54,7 +72,7 @@
         </Grid>
 
         <!-- Основные списки -->
-        <Grid Grid.Row="3">
+        <Grid Grid.Row="4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
## Summary
- refactor navigation logic into new `FilePane` class
- add buttons for creating folders and files as well as copy/move operations
- support switching panes with Tab and use active pane for operations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684371a20d6483229d3c65b7bfe21802