### PR TITLE
Fix directory move call for compilation

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -183,7 +183,11 @@ namespace DamnSimpleFileManager
                     }
                     else if (item is DirectoryInfo)
                     {
-                        Directory.Move(item.FullName, target, true);
+                        if (Directory.Exists(target))
+                        {
+                            Directory.Delete(target, true);
+                        }
+                        Directory.Move(item.FullName, target);
                     }
                     source.LoadDirectory(source.CurrentDir);
                     dest.LoadDirectory(dest.CurrentDir);


### PR DESCRIPTION
## Summary
- avoid non-existent Directory.Move overload by removing overwrite parameter and deleting any existing destination before move

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68986a6227ac8322a541212651de71ea