### PR TITLE
Add disk space info to file manager panes

### DIFF
--- a/FilePane.cs
+++ b/FilePane.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -11,16 +12,18 @@ namespace DamnSimpleFileManager
         public TextBlock PathText { get; }
         public ComboBox DriveSelector { get; }
         public Button BackButton { get; }
+        public TextBlock SpaceText { get; }
 
         public DirectoryInfo CurrentDir { get; private set; } = null!;
         private readonly Stack<DirectoryInfo> history = new();
 
-        public FilePane(ListView list, TextBlock pathText, ComboBox driveSelector, Button backButton)
+        public FilePane(ListView list, TextBlock pathText, ComboBox driveSelector, Button backButton, TextBlock spaceText)
         {
             List = list;
             PathText = pathText;
             DriveSelector = driveSelector;
             BackButton = backButton;
+            SpaceText = spaceText;
         }
 
         public void PopulateDrives()
@@ -59,6 +62,30 @@ namespace DamnSimpleFileManager
             foreach (var f in dir.GetFiles()) items.Add(f);
             List.ItemsSource = items;
             PathText.Text = dir.FullName;
+
+            UpdateDriveInfo(dir);
+        }
+
+        private void UpdateDriveInfo(DirectoryInfo dir)
+        {
+            var drive = new DriveInfo(dir.Root.FullName);
+            long total = drive.TotalSize;
+            long free = drive.TotalFreeSpace;
+            long used = total - free;
+            SpaceText.Text = $"Total: {FormatBytes(total)}  Used: {FormatBytes(used)}  Free: {FormatBytes(free)}";
+        }
+
+        private static string FormatBytes(long bytes)
+        {
+            string[] sizes = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
+            double len = bytes;
+            int order = 0;
+            while (len >= 1024 && order < sizes.Length - 1)
+            {
+                order++;
+                len /= 1024;
+            }
+            return $"{len:0.##} {sizes[order]}";
         }
 
         public void NavigateInto(DirectoryInfo dir)

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -15,6 +15,8 @@
             <!-- Пути -->
             <RowDefinition Height="*"/>
             <!-- Списки -->
+            <RowDefinition Height="Auto"/>
+            <!-- Информация о диске -->
         </Grid.RowDefinitions>
 
         <!-- Диски -->
@@ -83,6 +85,18 @@
             <Label Grid.Column="1" Width="10"/>
             <ListView x:Name="RightList" Grid.Column="2" DisplayMemberPath="Name"
                       MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
+        </Grid>
+
+        <!-- Информация о диске -->
+        <Grid Grid.Row="5" Margin="5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Name="LeftSpaceText" Grid.Column="0" Margin="5,0" />
+            <Label Grid.Column="1" Width="10"/>
+            <TextBlock x:Name="RightSpaceText" Grid.Column="2" Margin="5,0" HorizontalAlignment="Right"/>
         </Grid>
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -19,8 +19,8 @@ namespace DamnSimpleFileManager
         public MainWindow()
         {
             InitializeComponent();
-            leftPane = new FilePane(LeftList, LeftPathText, LeftDriveSelector, LeftBackButton);
-            rightPane = new FilePane(RightList, RightPathText, RightDriveSelector, RightBackButton);
+            leftPane = new FilePane(LeftList, LeftPathText, LeftDriveSelector, LeftBackButton, LeftSpaceText);
+            rightPane = new FilePane(RightList, RightPathText, RightDriveSelector, RightBackButton, RightSpaceText);
             PopulateDriveSelectors();
 
             activePane = leftPane;


### PR DESCRIPTION
## Summary
- Add status row with drive space details at bottom of each pane
- Compute and display total, used, and free space for current drive

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689872fc402c83228548913d696ac559