### PR TITLE
Enable multi-selection across file lists

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -80,11 +80,11 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <ListView x:Name="LeftList" Grid.Column="0" DisplayMemberPath="Name"
-                      MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
+            <ListView x:Name="LeftList" Grid.Column="0" DisplayMemberPath="Name" SelectionMode="Extended"
+                      PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
             <Label Grid.Column="1" Width="10"/>
-            <ListView x:Name="RightList" Grid.Column="2" DisplayMemberPath="Name"
-                      MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
+            <ListView x:Name="RightList" Grid.Column="2" DisplayMemberPath="Name" SelectionMode="Extended"
+                      PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
         </Grid>
 
         <!-- Информация о диске -->


### PR DESCRIPTION
## Summary
- allow selecting multiple items in each file list with Extended mode
- copy, move, and open actions iterate through all selected files
- toggle item selection with the space bar

## Testing
- `dotnet build` *(fails: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689877629f908322b5bcd6eed1f322a8