### PR TITLE
Show file type indicator before file names

### DIFF
--- a/FileTypeConverter.cs
+++ b/FileTypeConverter.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Windows.Data;
+
+namespace DamnSimpleFileManager
+{
+    /// <summary>
+    /// Converts FileSystemInfo to a string representing either a folder marker or file extension.
+    /// </summary>
+    public class FileTypeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is DirectoryInfo)
+            {
+                return "📁"; // folder icon
+            }
+            if (value is FileInfo fi)
+            {
+                return string.IsNullOrEmpty(fi.Extension) ? "FILE" : fi.Extension.TrimStart('.').ToUpperInvariant();
+            }
+            return string.Empty;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,8 +1,22 @@
 ﻿<Window x:Class="DamnSimpleFileManager.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:DamnSimpleFileManager"
         Title="Damn Simple File Manager" Height="768" Width="1040"
         PreviewKeyDown="Window_PreviewKeyDown">
+    <Window.Resources>
+        <local:FileTypeConverter x:Key="FileTypeConverter" />
+        <DataTemplate x:Key="FileItemTemplate">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{Binding Converter={StaticResource FileTypeConverter}}" Width="50" Margin="0,0,5,0" />
+                <TextBlock Grid.Column="1" Text="{Binding Name}" />
+            </Grid>
+        </DataTemplate>
+    </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -98,10 +112,10 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <ListView x:Name="LeftList" Grid.Column="0" DisplayMemberPath="Name" SelectionMode="Extended"
+            <ListView x:Name="LeftList" Grid.Column="0" ItemTemplate="{StaticResource FileItemTemplate}" SelectionMode="Extended"
                       PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
             <Label Grid.Column="1" Width="10"/>
-            <ListView x:Name="RightList" Grid.Column="2" DisplayMemberPath="Name" SelectionMode="Extended"
+            <ListView x:Name="RightList" Grid.Column="2" ItemTemplate="{StaticResource FileItemTemplate}" SelectionMode="Extended"
                       PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
         </Grid>
 


### PR DESCRIPTION
## Summary
- add `FileTypeConverter` to supply folder or extension markers
- display file type indicator before file names using a reusable item template

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899e33928648322ae89de060507ec3d