### PR TITLE
Add parent directory navigation entry

### DIFF
--- a/FilePane.cs
+++ b/FilePane.cs
@@ -65,6 +65,10 @@ namespace DamnSimpleFileManager
             }
 
             var items = new ObservableCollection<FileSystemInfo>();
+            if (dir.Parent != null)
+            {
+                items.Add(new ParentDirectoryInfo(dir.Parent.FullName));
+            }
             foreach (var d in dir.GetDirectories()) items.Add(d);
             foreach (var f in dir.GetFiles()) items.Add(f);
             List.ItemsSource = items;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -139,7 +139,7 @@ namespace DamnSimpleFileManager
         private void List_RightClick(object sender, MouseButtonEventArgs e)
         {
             var list = (ListView)sender;
-            if (list.SelectedItem is FileSystemInfo selectedItem)
+            if (list.SelectedItem is FileSystemInfo selectedItem && selectedItem is not ParentDirectoryInfo)
             {
                 try
                 {
@@ -186,7 +186,7 @@ namespace DamnSimpleFileManager
         {
             var source = ActivePane;
             var dest = InactivePane;
-            foreach (FileSystemInfo item in source.List.SelectedItems.Cast<FileSystemInfo>().ToList())
+            foreach (FileSystemInfo item in source.List.SelectedItems.Cast<FileSystemInfo>().Where(i => i is not ParentDirectoryInfo).ToList())
             {
                 string target = Path.Combine(dest.CurrentDir.FullName, item.Name);
                 try
@@ -212,7 +212,7 @@ namespace DamnSimpleFileManager
         {
             var source = ActivePane;
             var dest = InactivePane;
-            foreach (FileSystemInfo item in source.List.SelectedItems.Cast<FileSystemInfo>().ToList())
+            foreach (FileSystemInfo item in source.List.SelectedItems.Cast<FileSystemInfo>().Where(i => i is not ParentDirectoryInfo).ToList())
             {
                 string target = Path.Combine(dest.CurrentDir.FullName, item.Name);
                 try
@@ -242,7 +242,7 @@ namespace DamnSimpleFileManager
         private void Delete_Click(object sender, RoutedEventArgs e)
         {
             var pane = ActivePane;
-            var selectedItems = pane.List.SelectedItems.Cast<FileSystemInfo>().ToList();
+            var selectedItems = pane.List.SelectedItems.Cast<FileSystemInfo>().Where(i => i is not ParentDirectoryInfo).ToList();
             if (selectedItems.Count == 0)
                 return;
 

--- a/ParentDirectoryInfo.cs
+++ b/ParentDirectoryInfo.cs
@@ -1,0 +1,13 @@
+using System.IO;
+
+namespace DamnSimpleFileManager
+{
+    internal class ParentDirectoryInfo : DirectoryInfo
+    {
+        public ParentDirectoryInfo(string path) : base(path)
+        {
+        }
+
+        public new string Name => "..";
+    }
+}


### PR DESCRIPTION
## Summary
- Add a `ParentDirectoryInfo` item that reports its name as `..`
- Insert the parent entry at the top of each file list when available
- Ignore the parent item for copy, move, delete and context menu actions

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899e4e730808322aa08600b4dec25a4