### PR TITLE
Improve ParentDirectoryInfo resilience

### DIFF
--- a/ParentDirectoryInfo.cs
+++ b/ParentDirectoryInfo.cs
@@ -5,13 +5,24 @@ using System.Runtime.Serialization;
 namespace DamnSimpleFileManager
 {
     [Serializable]
-    internal class ParentDirectoryInfo : FileSystemInfo
+    internal sealed class ParentDirectoryInfo : FileSystemInfo
     {
         private readonly DirectoryInfo inner;
 
         public ParentDirectoryInfo(string path)
         {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("Path cannot be null or empty", nameof(path));
+            }
+
             inner = new DirectoryInfo(path);
+        }
+
+        protected ParentDirectoryInfo(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            var fullName = info.GetString("ParentDirectoryInnerFullName")!;
+            inner = new DirectoryInfo(fullName);
         }
 
         public override string Name => "..";


### PR DESCRIPTION
## Summary
- validate parent directory path before usage
- support serialization/deserialization for ParentDirectoryInfo
- mark ParentDirectoryInfo as sealed for clearer intent

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f564ef2083228778ff3f4737b653