### PR TITLE
chore: bump target framework to .NET 9

### DIFF
--- a/FileManager.csproj
+++ b/FileManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
## Summary
- target the latest .NET SDK

## Testing
- `dotnet build` (fails: `command not found`)


------
https://chatgpt.com/codex/tasks/task_e_689a005810b4832287f9cec652044ec9