### PR TITLE
Detect system language and fallback to English

### DIFF
--- a/Localization.cs
+++ b/Localization.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 namespace DamnSimpleFileManager
@@ -10,10 +11,25 @@ namespace DamnSimpleFileManager
 
         public static void LoadLanguage(string name)
         {
+            _strings.Clear();
+            if (!TryLoadLanguage(name))
+            {
+                TryLoadLanguage("English");
+            }
+        }
+
+        public static void LoadSystemLanguage()
+        {
+            var language = CultureInfo.CurrentUICulture.EnglishName.Split('(')[0].Trim();
+            LoadLanguage(language);
+        }
+
+        private static bool TryLoadLanguage(string name)
+        {
             var baseDir = AppContext.BaseDirectory;
             var path = Path.Combine(baseDir, "Languages", $"{name}.lang");
             if (!File.Exists(path))
-                return;
+                return false;
 
             foreach (var line in File.ReadAllLines(path))
             {
@@ -25,6 +41,8 @@ namespace DamnSimpleFileManager
                     _strings[parts[0].Trim()] = parts[1].Trim();
                 }
             }
+
+            return true;
         }
 
         public static string Get(string key) => _strings.TryGetValue(key, out var value) ? value : key;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -18,7 +18,7 @@ namespace DamnSimpleFileManager
         public MainWindow()
         {
             InitializeComponent();
-            Localization.LoadLanguage("English");
+            Localization.LoadSystemLanguage();
             ApplyLocalization();
 
             leftPane = new FilePane(LeftList, LeftPathText, LeftDriveSelector, LeftBackButton, LeftSpaceText);


### PR DESCRIPTION
## Summary
- detect system language at startup
- fall back to English when the system language or translation file is unavailable

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689a07371ae48322b2bd36b104dc669b