### PR TITLE
Add hidden files setting to dsfm.ini

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Configuration;
-using System.Data;
-using System.Windows;
+﻿using System.Windows;
 
 namespace DamnSimpleFileManager
 {
@@ -9,6 +7,11 @@ namespace DamnSimpleFileManager
     /// </summary>
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            Settings.Load();
+        }
     }
 
 }

--- a/FilePane.cs
+++ b/FilePane.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -69,8 +70,10 @@ namespace DamnSimpleFileManager
             {
                 items.Add(new ParentDirectoryInfo(dir.Parent.FullName));
             }
-            foreach (var d in dir.GetDirectories()) items.Add(d);
-            foreach (var f in dir.GetFiles()) items.Add(f);
+            foreach (var d in dir.GetDirectories().Where(d => Settings.ShowHiddenFiles || !d.Attributes.HasFlag(FileAttributes.Hidden)))
+                items.Add(d);
+            foreach (var f in dir.GetFiles().Where(f => Settings.ShowHiddenFiles || !f.Attributes.HasFlag(FileAttributes.Hidden)))
+                items.Add(f);
             List.ItemsSource = items;
             PathText.Text = dir.FullName;
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ The application is intentionally minimalistic and aims to offer a straightforwar
 - Keyboard support and simple navigation
 - Create, copy, move, and delete files or folders
 - Displays drive information and available space
+- Configurable behavior via `dsfm.ini`
+
+## Configuration
+
+`dsfm.ini` is created automatically next to the application.  
+Set `hidden_files=false` to hide files and folders marked as hidden.
 
 ## Building
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace DamnSimpleFileManager
+{
+    internal static class Settings
+    {
+        private static readonly string ConfigPath = Path.Combine(AppContext.BaseDirectory, "dsfm.ini");
+        private static readonly Dictionary<string, string> Values = new();
+
+        public static bool ShowHiddenFiles =>
+            Values.TryGetValue("hidden_files", out var value)
+                ? value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                : true;
+
+        public static void Load()
+        {
+            Values.Clear();
+            if (File.Exists(ConfigPath))
+            {
+                foreach (var line in File.ReadAllLines(ConfigPath))
+                {
+                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#") || line.StartsWith(";"))
+                        continue;
+                    var parts = line.Split('=', 2);
+                    if (parts.Length == 2)
+                        Values[parts[0].Trim().ToLowerInvariant()] = parts[1].Trim();
+                }
+            }
+
+            if (!Values.ContainsKey("hidden_files"))
+            {
+                Values["hidden_files"] = "true";
+                Save();
+            }
+        }
+
+        public static void Save()
+        {
+            var lines = new List<string>();
+            foreach (var kvp in Values)
+            {
+                lines.Add($"{kvp.Key}={kvp.Value}");
+            }
+            File.WriteAllLines(ConfigPath, lines);
+        }
+
+        public static void Set(string key, string value)
+        {
+            Values[key] = value;
+            Save();
+        }
+
+        public static string Get(string key, string defaultValue = "") =>
+            Values.TryGetValue(key, out var value) ? value : defaultValue;
+    }
+}
+

--- a/dsfm.ini
+++ b/dsfm.ini
@@ -1,0 +1,1 @@
+hidden_files=true


### PR DESCRIPTION
## Summary
- add Settings manager to load/save `dsfm.ini` with a default `hidden_files=true`
- hide files and folders marked hidden when `hidden_files=false`
- document configuration support and provide default config file

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package dotnet-sdk-9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689b0a33532083228184dc19d23ad1ec