### PR TITLE
Highlight directory icons in yellow

### DIFF
--- a/FileForegroundConverter.cs
+++ b/FileForegroundConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace DamnSimpleFileManager
+{
+    /// <summary>
+    /// Provides foreground brush based on the file system entry type.
+    /// </summary>
+    public class FileForegroundConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is DirectoryInfo || value is ParentDirectoryInfo)
+            {
+                return Brushes.Yellow;
+            }
+            return SystemColors.ControlTextBrush;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -6,13 +6,16 @@
         PreviewKeyDown="Window_PreviewKeyDown">
     <Window.Resources>
         <local:FileTypeConverter x:Key="FileTypeConverter" />
+        <local:FileForegroundConverter x:Key="FileForegroundConverter" />
         <DataTemplate x:Key="FileItemTemplate">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <TextBlock Text="{Binding Converter={StaticResource FileTypeConverter}}" Width="50" Margin="0,0,5,0" />
+                <TextBlock Text="{Binding Converter={StaticResource FileTypeConverter}}"
+                           Width="50" Margin="0,0,5,0"
+                           Foreground="{Binding Converter={StaticResource FileForegroundConverter}}" />
                 <TextBlock Grid.Column="1" Text="{Binding Name}" />
             </Grid>
         </DataTemplate>


### PR DESCRIPTION
## Summary
- add FileForegroundConverter to color directory icons yellow
- apply converter only to the icon so folder names remain default color

## Testing
- `apt-get update` *(fails: repository '... InRelease' is not signed)*
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689bbe92ce108322ac294eb9a2e0bf93