### PR TITLE
Improve folder icon visibility

### DIFF
--- a/FileForegroundConverter.cs
+++ b/FileForegroundConverter.cs
@@ -16,7 +16,7 @@ namespace DamnSimpleFileManager
         {
             if (value is DirectoryInfo || value is ParentDirectoryInfo)
             {
-                return Brushes.Yellow;
+                return Brushes.DeepSkyBlue;
             }
             return SystemColors.ControlTextBrush;
         }

--- a/FileTypeConverter.cs
+++ b/FileTypeConverter.cs
@@ -14,7 +14,7 @@ namespace DamnSimpleFileManager
         {
             if (value is DirectoryInfo)
             {
-                return "📁"; // folder icon
+                return "🗂"; // folder icon with improved visibility
             }
             if (value is FileInfo fi)
             {


### PR DESCRIPTION
## Summary
- use multi-colored card index emoji to represent folders
- switch folder foreground brush to DeepSkyBlue for better contrast

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc2bdc01c8322a87978d857f0fdb9