### PR TITLE
Assert non-null language names

### DIFF
--- a/Localization.cs
+++ b/Localization.cs
@@ -69,6 +69,7 @@ namespace DamnSimpleFileManager
             return Directory.GetFiles(dir, "*.lang")
                 .Select(Path.GetFileNameWithoutExtension)
                 .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Select(n => n!)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
     }


### PR DESCRIPTION
## Summary
- ensure loaded language names are non-null

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)
- `apt-get install -y dotnet-sdk-6.0` *(fails: Unable to locate package dotnet-sdk-6.0)*

------
https://chatgpt.com/codex/tasks/task_e_689bcb3aed5c8322b90098eba9fd833a