### PR TITLE
refactor key bindings to use file service

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Microsoft.VisualBasic;
 using DamnSimpleFileManager.Services;
 
 namespace DamnSimpleFileManager
@@ -144,25 +143,25 @@ namespace DamnSimpleFileManager
             }
             else if (e.Key == Key.F5)
             {
-                Copy_Click(null, null);
+                fileOperationsService.Copy(ActivePane, InactivePane, this);
                 e.Handled = true;
             }
             else if (e.Key == Key.F6)
             {
-                Move_Click(null, null);
+                fileOperationsService.Move(ActivePane, InactivePane, this);
                 e.Handled = true;
             }
             else if (e.Key == Key.F7)
             {
                 if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
-                    CreateFile_Click(null, null);
+                    fileOperationsService.CreateFile(ActivePane, this);
                 else
-                    CreateFolder_Click(null, null);
+                    fileOperationsService.CreateFolder(ActivePane, this);
                 e.Handled = true;
             }
             else if (e.Key == Key.F8)
             {
-                Delete_Click(null, null);
+                fileOperationsService.Delete(ActivePane, this);
                 e.Handled = true;
             }
         }
@@ -247,46 +246,14 @@ namespace DamnSimpleFileManager
         private FilePane ActivePane => activePane;
         private FilePane InactivePane => activePane == leftPane ? rightPane : leftPane;
 
-        private static bool ValidateName(string name)
-        {
-            if (Path.IsPathRooted(name) || name.Contains("..") || name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
-            {
-                MessageBox.Show(Application.Current.MainWindow!, Localization.Get("Error_InvalidName"), Localization.Get("Error_InvalidName_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
-                return false;
-            }
-            return true;
-        }
-
         private void CreateFolder_Click(object sender, RoutedEventArgs e)
         {
-            var pane = ActivePane;
-            string name = Interaction.InputBox(
-                Localization.Get("Prompt_FolderName"),
-                Localization.Get("Prompt_CreateFolder"),
-                Localization.Get("Default_FolderName"),
-                (int)(Left + (ActualWidth - 300) / 2),
-                (int)(Top + (ActualHeight - 150) / 2)).Trim();
-            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name))
-            {
-                Directory.CreateDirectory(Path.Combine(pane.CurrentDir.FullName, name));
-                pane.LoadDirectory(pane.CurrentDir);
-            }
+            fileOperationsService.CreateFolder(ActivePane, this);
         }
 
         private void CreateFile_Click(object sender, RoutedEventArgs e)
         {
-            var pane = ActivePane;
-            string name = Interaction.InputBox(
-                Localization.Get("Prompt_FileName"),
-                Localization.Get("Prompt_CreateFile"),
-                Localization.Get("Default_FileName"),
-                (int)(Left + (ActualWidth - 300) / 2),
-                (int)(Top + (ActualHeight - 150) / 2)).Trim();
-            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name))
-            {
-                File.Create(Path.Combine(pane.CurrentDir.FullName, name)).Close();
-                pane.LoadDirectory(pane.CurrentDir);
-            }
+            fileOperationsService.CreateFile(ActivePane, this);
         }
 
         private void Copy_Click(object sender, RoutedEventArgs e)

--- a/Services/FileOperationsService.cs
+++ b/Services/FileOperationsService.cs
@@ -2,12 +2,43 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using Microsoft.VisualBasic;
 using DamnSimpleFileManager;
 
 namespace DamnSimpleFileManager.Services
 {
     public class FileOperationsService
     {
+        public void CreateFolder(FilePane pane, Window owner)
+        {
+            string name = Interaction.InputBox(
+                Localization.Get("Prompt_FolderName"),
+                Localization.Get("Prompt_CreateFolder"),
+                Localization.Get("Default_FolderName"),
+                (int)(owner.Left + (owner.ActualWidth - 300) / 2),
+                (int)(owner.Top + (owner.ActualHeight - 150) / 2)).Trim();
+            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name, owner))
+            {
+                Directory.CreateDirectory(Path.Combine(pane.CurrentDir.FullName, name));
+                pane.LoadDirectory(pane.CurrentDir);
+            }
+        }
+
+        public void CreateFile(FilePane pane, Window owner)
+        {
+            string name = Interaction.InputBox(
+                Localization.Get("Prompt_FileName"),
+                Localization.Get("Prompt_CreateFile"),
+                Localization.Get("Default_FileName"),
+                (int)(owner.Left + (owner.ActualWidth - 300) / 2),
+                (int)(owner.Top + (owner.ActualHeight - 150) / 2)).Trim();
+            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name, owner))
+            {
+                File.Create(Path.Combine(pane.CurrentDir.FullName, name)).Close();
+                pane.LoadDirectory(pane.CurrentDir);
+            }
+        }
+
         public void Copy(FilePane source, FilePane dest, Window owner)
         {
             foreach (FileSystemInfo item in source.List.SelectedItems.Cast<FileSystemInfo>().Where(i => i is not ParentDirectoryInfo).ToList())
@@ -162,6 +193,16 @@ namespace DamnSimpleFileManager.Services
                     throw;
                 }
             }
+        }
+
+        private static bool ValidateName(string name, Window owner)
+        {
+            if (Path.IsPathRooted(name) || name.Contains("..") || name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                MessageBox.Show(owner, Localization.Get("Error_InvalidName"), Localization.Get("Error_InvalidName_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
+                return false;
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid event handler indirection and invoke file operations service directly on key presses
- expose create folder and file operations from service
- consolidate validation logic for new names

## Testing
- `dotnet build` *(fails: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689bcb3d9e948322aee5b38a2661c9bd