### PR TITLE
Remove redundant file include from project file

### DIFF
--- a/FileManager.csproj
+++ b/FileManager.csproj
@@ -15,8 +15,4 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="Services\FileOperationsService.cs" />
-  </ItemGroup>
-
-</Project>
+  </Project>


### PR DESCRIPTION
## Summary
- Drop manual inclusion of FileOperationsService.cs since the SDK handles source discovery by default

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689bcb37195c8322a4abedac502e5a12