### PR TITLE
Fix FileOperationsService accessibility

### DIFF
--- a/Services/FileOperationsService.cs
+++ b/Services/FileOperationsService.cs
@@ -6,7 +6,7 @@ using DamnSimpleFileManager;
 
 namespace DamnSimpleFileManager.Services
 {
-    public class FileOperationsService
+    internal class FileOperationsService
     {
         public void Copy(FilePane source, FilePane dest, Window owner)
         {


### PR DESCRIPTION
## Summary
- match service visibility with FilePane by making `FileOperationsService` internal

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bcd25fdf88322a9ed124025c3bccc