### PR TITLE
Enable resizable list views with GridSplitter

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -148,7 +148,7 @@
             </Grid.ColumnDefinitions>
             <ListView x:Name="LeftList" Grid.Column="0" ItemTemplate="{StaticResource FileItemTemplate}" SelectionMode="Extended"
                       PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
-            <Label Grid.Column="1" Width="10"/>
+            <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Center" Background="Transparent"/>
             <ListView x:Name="RightList" Grid.Column="2" ItemTemplate="{StaticResource FileItemTemplate}" SelectionMode="Extended"
                       PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
         </Grid>


### PR DESCRIPTION
## Summary
- replace static spacer with GridSplitter between file list views
- ensure adjacent columns use star sizing for dynamic resizing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden for Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_689bdd7ab98083228c2da7c842b66fab