### PR TITLE
Fix DriveInfo conflict preventing build

### DIFF
--- a/Models/FilePaneViewModel.cs
+++ b/Models/FilePaneViewModel.cs
@@ -81,7 +81,7 @@ namespace DamnSimpleFileManager
         public void PopulateDrives()
         {
             Drives.Clear();
-            foreach (var drive in DriveInfo.GetDrives())
+            foreach (var drive in System.IO.DriveInfo.GetDrives())
             {
                 if (drive.IsReady)
                 {
@@ -146,7 +146,7 @@ namespace DamnSimpleFileManager
 
         private void UpdateDriveInfo(DirectoryInfo dir)
         {
-            var drive = new DriveInfo(dir.Root.FullName);
+            var drive = new System.IO.DriveInfo(dir.Root.FullName);
             long total = drive.TotalSize;
             long free = drive.TotalFreeSpace;
             long used = total - free;


### PR DESCRIPTION
## Summary
- Fully qualify `System.IO.DriveInfo` usage to avoid collision with `DriveInfo` property

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors prevent installation)*

------
https://chatgpt.com/codex/tasks/task_e_689c6a71fbf083229b4eb573f2f3b212