### PR TITLE
refactor: move About window into Windows folder

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.VisualBasic;
 using DamnSimpleFileManager.Services;
+using DamnSimpleFileManager.Windows;
 
 namespace DamnSimpleFileManager
 {

--- a/Windows/AboutWindow.xaml
+++ b/Windows/AboutWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="DamnSimpleFileManager.AboutWindow"
+<Window x:Class="DamnSimpleFileManager.Windows.AboutWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="About" Height="200" Width="300"

--- a/Windows/AboutWindow.xaml.cs
+++ b/Windows/AboutWindow.xaml.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Windows.Navigation;
 using System.Reflection;
 
-namespace DamnSimpleFileManager
+namespace DamnSimpleFileManager.Windows
 {
     public partial class AboutWindow : Window
     {


### PR DESCRIPTION
## Summary
- Move AboutWindow XAML and code-behind into new Windows directory
- Adjust namespaces and references for AboutWindow

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c6c30cb08832289dfbe906c14f041