### PR TITLE
Show keyboard shortcuts in menus and toolbar

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -39,12 +39,12 @@
         <!-- Меню -->
         <Menu Grid.Row="0">
             <MenuItem x:Name="FileMenu" Header="_File">
-                <MenuItem x:Name="NewFolderMenuItem" Header="_New Folder" Click="CreateFolder_Click"/>
-                <MenuItem x:Name="NewFileMenuItem" Header="New _File" Click="CreateFile_Click"/>
+                <MenuItem x:Name="NewFolderMenuItem" Header="_New Folder" Click="CreateFolder_Click" InputGestureText="F7"/>
+                <MenuItem x:Name="NewFileMenuItem" Header="New _File" Click="CreateFile_Click" InputGestureText="Shift+F7"/>
                 <Separator/>
-                <MenuItem x:Name="CopyMenuItem" Header="_Copy" Click="Copy_Click"/>
-                <MenuItem x:Name="MoveMenuItem" Header="_Move" Click="Move_Click"/>
-                <MenuItem x:Name="DeleteMenuItem" Header="_Delete" Click="Delete_Click"/>
+                <MenuItem x:Name="CopyMenuItem" Header="_Copy" Click="Copy_Click" InputGestureText="F5"/>
+                <MenuItem x:Name="MoveMenuItem" Header="_Move" Click="Move_Click" InputGestureText="F6"/>
+                <MenuItem x:Name="DeleteMenuItem" Header="_Delete" Click="Delete_Click" InputGestureText="F8"/>
                 <Separator/>
                 <MenuItem x:Name="OpenTerminalMenuItem" Header="_Open Terminal" Click="OpenTerminal_Click"/>
                 <Separator/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -53,19 +53,24 @@ namespace DamnSimpleFileManager
             Title = Localization.Get("App_Title");
             FileMenu.Header = Localization.Get("Menu_File");
             NewFolderMenuItem.Header = Localization.Get("Menu_NewFolder");
+            NewFolderMenuItem.InputGestureText = "F7";
             NewFileMenuItem.Header = Localization.Get("Menu_NewFile");
+            NewFileMenuItem.InputGestureText = "Shift+F7";
             CopyMenuItem.Header = Localization.Get("Menu_Copy");
+            CopyMenuItem.InputGestureText = "F5";
             MoveMenuItem.Header = Localization.Get("Menu_Move");
+            MoveMenuItem.InputGestureText = "F6";
             DeleteMenuItem.Header = Localization.Get("Menu_Delete");
+            DeleteMenuItem.InputGestureText = "F8";
             OpenTerminalMenuItem.Header = Localization.Get("Menu_OpenTerminal");
             ExitMenuItem.Header = Localization.Get("Menu_Exit");
             HelpMenu.Header = Localization.Get("Menu_Help");
             AboutMenuItem.Header = Localization.Get("Menu_About");
-            CreateFolderText.Text = Localization.Get("Button_CreateFolder");
-            CreateFileText.Text = Localization.Get("Button_CreateFile");
-            CopyText.Text = Localization.Get("Button_Copy");
-            MoveText.Text = Localization.Get("Button_Move");
-            DeleteText.Text = Localization.Get("Button_Delete");
+            CreateFolderText.Text = Localization.Get("Button_CreateFolder") + " (F7)";
+            CreateFileText.Text = Localization.Get("Button_CreateFile") + " (Shift+F7)";
+            CopyText.Text = Localization.Get("Button_Copy") + " (F5)";
+            MoveText.Text = Localization.Get("Button_Move") + " (F6)";
+            DeleteText.Text = Localization.Get("Button_Delete") + " (F8)";
             TerminalText.Text = Localization.Get("Button_OpenTerminal");
         }
 


### PR DESCRIPTION
## Summary
- display F5/F6/F7/Shift+F7/F8 shortcuts next to file menu items
- append matching shortcut hints to toolbar button labels

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c726106ec832295b7b2ebfa32cd66