### PR TITLE
Refactor key bindings to use file service for file creation

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Microsoft.VisualBasic;
 using DamnSimpleFileManager.Services;
 using DamnSimpleFileManager.Windows;
 
@@ -171,25 +170,28 @@ namespace DamnSimpleFileManager
             }
             else if (e.Key == Key.F5)
             {
-                Copy_Click(null, null);
+                var items = ActiveList.SelectedItems.Cast<FileSystemInfo>().Where(i => i is not ParentDirectoryInfo).ToList();
+                fileOperationsService.Copy(ActivePane, InactivePane, items, this);
                 e.Handled = true;
             }
             else if (e.Key == Key.F6)
             {
-                Move_Click(null, null);
+                var items = ActiveList.SelectedItems.Cast<FileSystemInfo>().Where(i => i is not ParentDirectoryInfo).ToList();
+                fileOperationsService.Move(ActivePane, InactivePane, items, this);
                 e.Handled = true;
             }
             else if (e.Key == Key.F7)
             {
                 if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
-                    CreateFile_Click(null, null);
+                    fileOperationsService.CreateFile(ActivePane, this);
                 else
-                    CreateFolder_Click(null, null);
+                    fileOperationsService.CreateFolder(ActivePane, this);
                 e.Handled = true;
             }
             else if (e.Key == Key.F8)
             {
-                Delete_Click(null, null);
+                var items = ActiveList.SelectedItems.Cast<FileSystemInfo>().Where(i => i is not ParentDirectoryInfo).ToList();
+                fileOperationsService.Delete(ActivePane, items, this);
                 e.Handled = true;
             }
         }
@@ -249,46 +251,14 @@ namespace DamnSimpleFileManager
         private FilePaneViewModel InactivePane => activePane == leftPane ? rightPane : leftPane;
         private ListView ActiveList => activePane == leftPane ? LeftList : RightList;
 
-        private static bool ValidateName(string name)
-        {
-            if (Path.IsPathRooted(name) || name.Contains("..") || name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
-            {
-                MessageBox.Show(Application.Current.MainWindow!, Localization.Get("Error_InvalidName"), Localization.Get("Error_InvalidName_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
-                return false;
-            }
-            return true;
-        }
-
         private void CreateFolder_Click(object sender, RoutedEventArgs e)
         {
-            var pane = ActivePane;
-            string name = Interaction.InputBox(
-                Localization.Get("Prompt_FolderName"),
-                Localization.Get("Prompt_CreateFolder"),
-                Localization.Get("Default_FolderName"),
-                (int)(Left + (ActualWidth - 300) / 2),
-                (int)(Top + (ActualHeight - 150) / 2)).Trim();
-            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name))
-            {
-                Directory.CreateDirectory(Path.Combine(pane.CurrentDir.FullName, name));
-                pane.LoadDirectory(pane.CurrentDir);
-            }
+            fileOperationsService.CreateFolder(ActivePane, this);
         }
 
         private void CreateFile_Click(object sender, RoutedEventArgs e)
         {
-            var pane = ActivePane;
-            string name = Interaction.InputBox(
-                Localization.Get("Prompt_FileName"),
-                Localization.Get("Prompt_CreateFile"),
-                Localization.Get("Default_FileName"),
-                (int)(Left + (ActualWidth - 300) / 2),
-                (int)(Top + (ActualHeight - 150) / 2)).Trim();
-            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name))
-            {
-                File.Create(Path.Combine(pane.CurrentDir.FullName, name)).Close();
-                pane.LoadDirectory(pane.CurrentDir);
-            }
+            fileOperationsService.CreateFile(ActivePane, this);
         }
 
         private void Copy_Click(object sender, RoutedEventArgs e)

--- a/Services/FileOperationsService.cs
+++ b/Services/FileOperationsService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using Microsoft.VisualBasic;
 using DamnSimpleFileManager;
 
 namespace DamnSimpleFileManager.Services
@@ -110,6 +111,46 @@ namespace DamnSimpleFileManager.Services
             }
 
             pane.LoadDirectory(pane.CurrentDir);
+        }
+
+        public void CreateFolder(FilePaneViewModel pane, Window owner)
+        {
+            string name = Interaction.InputBox(
+                Localization.Get("Prompt_FolderName"),
+                Localization.Get("Prompt_CreateFolder"),
+                Localization.Get("Default_FolderName"),
+                (int)(owner.Left + (owner.ActualWidth - 300) / 2),
+                (int)(owner.Top + (owner.ActualHeight - 150) / 2)).Trim();
+            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name, owner))
+            {
+                Directory.CreateDirectory(Path.Combine(pane.CurrentDir.FullName, name));
+                pane.LoadDirectory(pane.CurrentDir);
+            }
+        }
+
+        public void CreateFile(FilePaneViewModel pane, Window owner)
+        {
+            string name = Interaction.InputBox(
+                Localization.Get("Prompt_FileName"),
+                Localization.Get("Prompt_CreateFile"),
+                Localization.Get("Default_FileName"),
+                (int)(owner.Left + (owner.ActualWidth - 300) / 2),
+                (int)(owner.Top + (owner.ActualHeight - 150) / 2)).Trim();
+            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name, owner))
+            {
+                File.Create(Path.Combine(pane.CurrentDir.FullName, name)).Close();
+                pane.LoadDirectory(pane.CurrentDir);
+            }
+        }
+
+        private static bool ValidateName(string name, Window owner)
+        {
+            if (Path.IsPathRooted(name) || name.Contains("..") || name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                MessageBox.Show(owner, Localization.Get("Error_InvalidName"), Localization.Get("Error_InvalidName_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
+                return false;
+            }
+            return true;
         }
 
         private static void CopyDirectory(string sourceDir, string destinationDir)


### PR DESCRIPTION
## Summary
- Invoke file operations service directly on key presses
- Move folder and file creation logic into the file service with shared name validation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c7504548c832288c783681ba03b65