### PR TITLE
Add YouTube channel link to About dialog

### DIFF
--- a/Windows/AboutWindow.xaml
+++ b/Windows/AboutWindow.xaml
@@ -12,6 +12,10 @@
                 <Hyperlink NavigateUri="https://github.com/deemoun/damn-simple-file-manager" RequestNavigate="Hyperlink_RequestNavigate">
                     Github repository
                 </Hyperlink>
+                <LineBreak/>
+                <Hyperlink NavigateUri="https://www.youtube.com/@NomadicDmitry/" RequestNavigate="Hyperlink_RequestNavigate">
+                    My YouTube channel
+                </Hyperlink>
             </TextBlock>
             <Button Content="OK" Width="80" Height="30" HorizontalAlignment="Center" Click="Close_Click"/>
         </StackPanel>


### PR DESCRIPTION
## Summary
- add hyperlink to My YouTube channel in About window below the GitHub repository link

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c78bbc7788322bba147903acbd801