### PR TITLE
Disable file operations when no items selected

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -43,9 +43,9 @@
                 <MenuItem x:Name="NewFileMenuItem" Header="New _File" Click="CreateFile_Click"/>
                 <MenuItem x:Name="ViewMenuItem" Header="_View" Click="View_Click" InputGestureText="F3" IsEnabled="False"/>
                 <Separator/>
-                <MenuItem x:Name="CopyMenuItem" Header="_Copy" Click="Copy_Click" InputGestureText="F5"/>
-                <MenuItem x:Name="MoveMenuItem" Header="_Move" Click="Move_Click" InputGestureText="F6"/>
-                <MenuItem x:Name="DeleteMenuItem" Header="_Delete" Click="Delete_Click" InputGestureText="F8"/>
+                <MenuItem x:Name="CopyMenuItem" Header="_Copy" Click="Copy_Click" InputGestureText="F5" IsEnabled="False"/>
+                <MenuItem x:Name="MoveMenuItem" Header="_Move" Click="Move_Click" InputGestureText="F6" IsEnabled="False"/>
+                <MenuItem x:Name="DeleteMenuItem" Header="_Delete" Click="Delete_Click" InputGestureText="F8" IsEnabled="False"/>
                 <Separator/>
                 <MenuItem x:Name="OpenTerminalMenuItem" Header="_Open Terminal" Click="OpenTerminal_Click"/>
                 <Separator/>
@@ -86,19 +86,19 @@
                         <TextBlock x:Name="ViewText"/>
                     </StackPanel>
                 </Button>
-                <Button x:Name="CopyButton" Width="110" Height="30" Margin="0,0,5,0" Click="Copy_Click">
+                <Button x:Name="CopyButton" Width="110" Height="30" Margin="0,0,5,0" Click="Copy_Click" IsEnabled="False">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="📋" Margin="0,0,5,0"/>
                         <TextBlock x:Name="CopyText"/>
                     </StackPanel>
                 </Button>
-                <Button x:Name="MoveButton" Width="110" Height="30" Margin="0,0,5,0" Click="Move_Click">
+                <Button x:Name="MoveButton" Width="110" Height="30" Margin="0,0,5,0" Click="Move_Click" IsEnabled="False">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="📂" Margin="0,0,5,0"/>
                         <TextBlock x:Name="MoveText"/>
                     </StackPanel>
                 </Button>
-                <Button x:Name="DeleteButton" Width="110" Height="30" Margin="0,0,5,0" Click="Delete_Click">
+                <Button x:Name="DeleteButton" Width="110" Height="30" Margin="0,0,5,0" Click="Delete_Click" IsEnabled="False">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="🗑️" Margin="0,0,5,0"/>
                         <TextBlock x:Name="DeleteText"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -47,8 +47,7 @@ namespace DamnSimpleFileManager
             RightList.GotFocus += List_GotFocus;
             LeftList.SelectionChanged += List_SelectionChanged;
             RightList.SelectionChanged += List_SelectionChanged;
-            ViewButton.IsEnabled = false;
-            ViewMenuItem.IsEnabled = false;
+            UpdateOperationsAvailability();
         }
 
         private void ApplyLocalization()
@@ -180,17 +179,25 @@ namespace DamnSimpleFileManager
             ViewSelectedFile();
         }
 
-        private void UpdateViewAvailability()
+        private void UpdateOperationsAvailability()
         {
-            var isEnabled = ActiveList.SelectedItems.Count == 1 && ActiveList.SelectedItem is FileInfo;
-            ViewButton.IsEnabled = isEnabled;
-            ViewMenuItem.IsEnabled = isEnabled;
+            var canView = ActiveList.SelectedItems.Count == 1 && ActiveList.SelectedItem is FileInfo;
+            ViewButton.IsEnabled = canView;
+            ViewMenuItem.IsEnabled = canView;
+
+            var hasItems = ActiveList.SelectedItems.Cast<FileSystemInfo>().Any(i => i is not ParentDirectoryInfo);
+            CopyButton.IsEnabled = hasItems;
+            CopyMenuItem.IsEnabled = hasItems;
+            MoveButton.IsEnabled = hasItems;
+            MoveMenuItem.IsEnabled = hasItems;
+            DeleteButton.IsEnabled = hasItems;
+            DeleteMenuItem.IsEnabled = hasItems;
         }
 
         private void List_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             activePane = ((ListView)sender) == LeftList ? leftPane : rightPane;
-            UpdateViewAvailability();
+            UpdateOperationsAvailability();
         }
 
         private void List_DoubleClick(object sender, MouseButtonEventArgs e)
@@ -297,7 +304,7 @@ namespace DamnSimpleFileManager
         private void List_GotFocus(object sender, RoutedEventArgs e)
         {
             activePane = ((ListView)sender) == LeftList ? leftPane : rightPane;
-            UpdateViewAvailability();
+            UpdateOperationsAvailability();
         }
 
         private FilePaneViewModel ActivePane => activePane;


### PR DESCRIPTION
## Summary
- Disable Copy, Move and Delete buttons/menu items until files or folders are selected
- Centralize selection-based enablement logic in a new UpdateOperationsAvailability method

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c8b1a20608322a20c60bcbef93460