### PR TITLE
Reset log file at 5MB size

### DIFF
--- a/Utils/Logger.cs
+++ b/Utils/Logger.cs
@@ -7,6 +7,7 @@ namespace DamnSimpleFileManager
     {
         private static readonly object _lock = new();
         private static readonly string LogPath = Path.Combine(AppContext.BaseDirectory, "dsfm.log");
+        private const long MaxLogSizeBytes = 5 * 1024 * 1024;
 
         public static void Log(string message)
         {
@@ -22,9 +23,13 @@ namespace DamnSimpleFileManager
         {
             try
             {
-                var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} [{level}] {message}{Environment.NewLine}";
+                var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} [{level}] {message}{Environment.NewLine}"; 
                 lock (_lock)
                 {
+                    if (File.Exists(LogPath) && new FileInfo(LogPath).Length >= MaxLogSizeBytes)
+                    {
+                        File.WriteAllText(LogPath, string.Empty);
+                    }
                     File.AppendAllText(LogPath, line);
                 }
             }


### PR DESCRIPTION
## Summary
- Clear dsfm.log when it reaches or exceeds 5MB to prevent unbounded growth.

## Testing
- `dotnet build FileManager.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c91ec3b7083229b8fd974fc9611b2