### PR TITLE
Show zero state message for empty drives

### DIFF
--- a/Languages/English.lang
+++ b/Languages/English.lang
@@ -47,3 +47,4 @@ DriveInfo_Free=Free
 SizeUnits=B,KB,MB,GB,TB,PB,EB
 Exception_PathNull=Path cannot be null or empty
 FileType_Default=FILE
+NoItemsMessage=No items found. Go add some!

--- a/Languages/Russian.lang
+++ b/Languages/Russian.lang
@@ -47,3 +47,4 @@ DriveInfo_Free=Свободно
 SizeUnits=Б,КБ,МБ,ГБ,ТБ,ПБ,ЭБ
 Exception_PathNull=Путь не может быть пустым
 FileType_Default=ФАЙЛ
+NoItemsMessage=Ничего не найдено. Добавьте что-нибудь!

--- a/Languages/Spanish.lang
+++ b/Languages/Spanish.lang
@@ -47,3 +47,4 @@ DriveInfo_Free=Libre
 SizeUnits=B,KB,MB,GB,TB,PB,EB
 Exception_PathNull=La ruta no puede estar vacía
 FileType_Default=ARCHIVO
+NoItemsMessage=No se encontraron elementos. ¡Ve y agrega algunos!

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -157,15 +157,45 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <ListView x:Name="LeftList" Grid.Column="0" ItemTemplate="{StaticResource FileItemTemplate}" SelectionMode="Extended"
-                      HorizontalContentAlignment="Stretch"
-                      ItemsSource="{Binding Items, Mode=OneWay}"
-                      PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
+            <Grid Grid.Column="0">
+                <ListView x:Name="LeftList" ItemTemplate="{StaticResource FileItemTemplate}" SelectionMode="Extended"
+                          HorizontalContentAlignment="Stretch"
+                          ItemsSource="{Binding Items, Mode=OneWay}"
+                          PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
+                <TextBlock DataContext="{Binding DataContext, ElementName=LeftList}" Text="{Binding NoItemsMessage}"
+                           HorizontalAlignment="Center" VerticalAlignment="Center" FontStyle="Italic" Foreground="Gray">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Items.Count}" Value="0">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
             <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Center" Background="Transparent"/>
-            <ListView x:Name="RightList" Grid.Column="2" ItemTemplate="{StaticResource FileItemTemplate}" SelectionMode="Extended"
-                      HorizontalContentAlignment="Stretch"
-                      ItemsSource="{Binding Items, Mode=OneWay}"
-                      PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
+            <Grid Grid.Column="2">
+                <ListView x:Name="RightList" ItemTemplate="{StaticResource FileItemTemplate}" SelectionMode="Extended"
+                          HorizontalContentAlignment="Stretch"
+                          ItemsSource="{Binding Items, Mode=OneWay}"
+                          PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick"/>
+                <TextBlock DataContext="{Binding DataContext, ElementName=RightList}" Text="{Binding NoItemsMessage}"
+                           HorizontalAlignment="Center" VerticalAlignment="Center" FontStyle="Italic" Foreground="Gray">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Items.Count}" Value="0">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
         </Grid>
 
         <!-- Информация о диске -->

--- a/Models/FilePaneViewModel.cs
+++ b/Models/FilePaneViewModel.cs
@@ -94,6 +94,7 @@ namespace DamnSimpleFileManager
         public string TotalLabel => Localization.Get("DriveInfo_Total") + ":";
         public string UsedLabel => Localization.Get("DriveInfo_Used") + ":";
         public string FreeLabel => Localization.Get("DriveInfo_Free") + ":";
+        public string NoItemsMessage => Localization.Get("NoItemsMessage");
 
         public DirectoryInfo CurrentDir { get; private set; } = null!;
         private readonly Stack<DirectoryInfo> history = new();


### PR DESCRIPTION
## Summary
- display a friendly 'No items found. Go add some!' message when a pane has no files
- expose `NoItemsMessage` on `FilePaneViewModel` and add translations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de6834ba48322b6f932459d112d23