### PR TITLE
Fix empty drive message when only hidden or system files exist

### DIFF
--- a/Models/FilePaneViewModel.cs
+++ b/Models/FilePaneViewModel.cs
@@ -140,9 +140,15 @@ namespace DamnSimpleFileManager
             {
                 Items.Add(new ParentDirectoryInfo(dir.Parent.FullName));
             }
-            foreach (var d in dir.GetDirectories().Where(d => Settings.ShowHiddenFiles || !d.Attributes.HasFlag(FileAttributes.Hidden)))
+            foreach (var d in dir.GetDirectories().Where(d =>
+                             Settings.ShowHiddenFiles ||
+                             (!d.Attributes.HasFlag(FileAttributes.Hidden) &&
+                              !d.Attributes.HasFlag(FileAttributes.System))))
                 Items.Add(d);
-            foreach (var f in dir.GetFiles().Where(f => Settings.ShowHiddenFiles || !f.Attributes.HasFlag(FileAttributes.Hidden)))
+            foreach (var f in dir.GetFiles().Where(f =>
+                             Settings.ShowHiddenFiles ||
+                             (!f.Attributes.HasFlag(FileAttributes.Hidden) &&
+                              !f.Attributes.HasFlag(FileAttributes.System))))
                 Items.Add(f);
 
             CurrentPath = dir.FullName;


### PR DESCRIPTION
## Summary
- Do not consider hidden or system entries when listing files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de899012c83229c3ff28b89344996