### PR TITLE
Add tools menu for system utilities

### DIFF
--- a/Languages/English.lang
+++ b/Languages/English.lang
@@ -48,3 +48,7 @@ SizeUnits=B,KB,MB,GB,TB,PB,EB
 Exception_PathNull=Path cannot be null or empty
 FileType_Default=FILE
 NoItemsMessage=No items found. Go add some!
+Menu_Tools=_Tools
+Menu_Services=_Services
+Menu_ControlPanel=Control _Panel
+Menu_System=_System

--- a/Languages/Russian.lang
+++ b/Languages/Russian.lang
@@ -48,3 +48,7 @@ SizeUnits=Б,КБ,МБ,ГБ,ТБ,ПБ,ЭБ
 Exception_PathNull=Путь не может быть пустым
 FileType_Default=ФАЙЛ
 NoItemsMessage=Ничего не найдено. Добавьте что-нибудь!
+Menu_Tools=_Сервис
+Menu_Services=_Службы
+Menu_ControlPanel=_Панель управления
+Menu_System=_Система

--- a/Languages/Spanish.lang
+++ b/Languages/Spanish.lang
@@ -48,3 +48,7 @@ SizeUnits=B,KB,MB,GB,TB,PB,EB
 Exception_PathNull=La ruta no puede estar vacía
 FileType_Default=ARCHIVO
 NoItemsMessage=No se encontraron elementos. ¡Ve y agrega algunos!
+Menu_Tools=_Herramientas
+Menu_Services=_Servicios
+Menu_ControlPanel=_Panel de control
+Menu_System=_Sistema

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -58,6 +58,11 @@
                 <Separator/>
                 <MenuItem x:Name="ExitMenuItem" Header="E_xit" Click="Exit_Click"/>
             </MenuItem>
+            <MenuItem x:Name="ToolsMenu" Header="_Tools">
+                <MenuItem x:Name="ServicesMenuItem" Header="Services" Click="OpenServices_Click"/>
+                <MenuItem x:Name="ControlPanelMenuItem" Header="Control Panel" Click="OpenControlPanel_Click"/>
+                <MenuItem x:Name="SystemMenuItem" Header="System" Click="OpenSystem_Click"/>
+            </MenuItem>
             <MenuItem x:Name="HelpMenu" Header="_Help">
                 <MenuItem x:Name="AboutMenuItem" Header="_About" Click="About_Click"/>
             </MenuItem>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -69,6 +69,10 @@ namespace DamnSimpleFileManager
             DeleteMenuItem.Header = Localization.Get("Menu_Delete");
             DeleteMenuItem.InputGestureText = "F8";
             OpenTerminalMenuItem.Header = Localization.Get("Menu_OpenTerminal");
+            ToolsMenu.Header = Localization.Get("Menu_Tools");
+            ServicesMenuItem.Header = Localization.Get("Menu_Services");
+            ControlPanelMenuItem.Header = Localization.Get("Menu_ControlPanel");
+            SystemMenuItem.Header = Localization.Get("Menu_System");
             ExitMenuItem.Header = Localization.Get("Menu_Exit");
             HelpMenu.Header = Localization.Get("Menu_Help");
             AboutMenuItem.Header = Localization.Get("Menu_About");
@@ -293,6 +297,24 @@ namespace DamnSimpleFileManager
                 Logger.LogError("Error opening terminal", ex);
                 MessageBox.Show(this, Localization.Get("Error_OpenTerminal", ex.Message));
             }
+        }
+
+        private void OpenServices_Click(object sender, RoutedEventArgs e)
+        {
+            Logger.Log("Open services clicked");
+            Process.Start(new ProcessStartInfo("services.msc") { UseShellExecute = true });
+        }
+
+        private void OpenControlPanel_Click(object sender, RoutedEventArgs e)
+        {
+            Logger.Log("Open Control Panel clicked");
+            Process.Start(new ProcessStartInfo("control") { UseShellExecute = true });
+        }
+
+        private void OpenSystem_Click(object sender, RoutedEventArgs e)
+        {
+            Logger.Log("Open System clicked");
+            Process.Start(new ProcessStartInfo("control", "system") { UseShellExecute = true });
         }
 
         private void Exit_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- add "Tools" menu with Services, Control Panel, and System options
- wire menu items to handlers launching Windows utilities
- localize new menu items in English, Russian, and Spanish

## Testing
- ⚠️ `dotnet build` *(missing dotnet SDK in environment)*

------
https://chatgpt.com/codex/tasks/task_e_689df839e67c8322bebd3b02a7c214a7