### PR TITLE
feat: add placeholders to lynkr inputs

### DIFF
--- a/Windows/LynkrWindow.xaml
+++ b/Windows/LynkrWindow.xaml
@@ -10,8 +10,12 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBox x:Name="UrlTextBox" Width="300" Margin="0,0,5,0"/>
-            <TextBox x:Name="DescriptionTextBox" Width="200" Margin="0,0,5,0"/>
+            <TextBox x:Name="UrlTextBox" Width="300" Margin="0,0,5,0"
+                     Text="Enter website address" Tag="Enter website address"
+                     GotFocus="TextBox_GotFocus" LostFocus="TextBox_LostFocus"/>
+            <TextBox x:Name="DescriptionTextBox" Width="200" Margin="0,0,5,0"
+                     Text="Enter title" Tag="Enter title"
+                     GotFocus="TextBox_GotFocus" LostFocus="TextBox_LostFocus"/>
             <Button Content="Add" Width="60" Click="Add_Click"/>
         </StackPanel>
         <ListView x:Name="LinksList" Grid.Row="1" Margin="0,0,0,10">

--- a/Windows/LynkrWindow.xaml.cs
+++ b/Windows/LynkrWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Controls;
 using Microsoft.Win32;
 using DamnSimpleFileManager.Utils;
 
@@ -16,17 +17,38 @@ namespace DamnSimpleFileManager.Windows
 
         private void Add_Click(object sender, RoutedEventArgs e)
         {
-            if (linkManager.AddLink(UrlTextBox.Text))
+            var url = UrlTextBox.Text.Trim();
+            if (url == (string)UrlTextBox.Tag)
+                url = string.Empty;
+
+            if (linkManager.AddLink(url))
             {
-                if (!string.IsNullOrWhiteSpace(DescriptionTextBox.Text))
-                    linkManager.SetDescription(UrlTextBox.Text.Trim(), DescriptionTextBox.Text.Trim());
-                UrlTextBox.Clear();
-                DescriptionTextBox.Clear();
+                var description = DescriptionTextBox.Text.Trim();
+                if (description != (string)DescriptionTextBox.Tag && !string.IsNullOrWhiteSpace(description))
+                    linkManager.SetDescription(url, description);
+                UrlTextBox.Text = (string)UrlTextBox.Tag;
+                DescriptionTextBox.Text = (string)DescriptionTextBox.Tag;
                 LinksList.Items.Refresh();
             }
             else
             {
                 MessageBox.Show(this, "Invalid URL", "Lynkr");
+            }
+        }
+
+        private void TextBox_GotFocus(object sender, RoutedEventArgs e)
+        {
+            if (sender is TextBox tb && tb.Text == tb.Tag?.ToString())
+            {
+                tb.Clear();
+            }
+        }
+
+        private void TextBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            if (sender is TextBox tb && string.IsNullOrWhiteSpace(tb.Text))
+            {
+                tb.Text = tb.Tag?.ToString();
             }
         }
 


### PR DESCRIPTION
## Summary
- add placeholder hints to link and title fields in Lynkr window
- reset placeholders after adding links
- support placeholder behavior on focus/blur

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e0d7586c0832283a888da74eabaac