### PR TITLE
Stretch Created column to available width

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -149,6 +149,7 @@
                 <ListView x:Name="LeftList" SelectionMode="Extended"
                           HorizontalContentAlignment="Stretch"
                           ItemsSource="{Binding Items, Mode=OneWay}"
+                          SizeChanged="List_SizeChanged"
                           PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick">
                     <ListView.View>
                         <GridView AllowsColumnReorder="False">
@@ -182,7 +183,7 @@
                                     </DataTemplate>
                                 </GridViewColumn.CellTemplate>
                             </GridViewColumn>
-                            <GridViewColumn Width="120">
+                            <GridViewColumn>
                                 <GridViewColumn.Header>
                                     <GridViewColumnHeader x:Name="LeftDateHeader" Tag="CreationTime" Click="GridViewColumnHeader_Click"/>
                                 </GridViewColumn.Header>
@@ -214,6 +215,7 @@
                 <ListView x:Name="RightList" SelectionMode="Extended"
                           HorizontalContentAlignment="Stretch"
                           ItemsSource="{Binding Items, Mode=OneWay}"
+                          SizeChanged="List_SizeChanged"
                           PreviewKeyDown="List_PreviewKeyDown" MouseDoubleClick="List_DoubleClick" MouseRightButtonUp="List_RightClick">
                     <ListView.View>
                         <GridView AllowsColumnReorder="False">
@@ -247,7 +249,7 @@
                                     </DataTemplate>
                                 </GridViewColumn.CellTemplate>
                             </GridViewColumn>
-                            <GridViewColumn Width="120">
+                            <GridViewColumn>
                                 <GridViewColumn.Header>
                                     <GridViewColumnHeader x:Name="RightDateHeader" Tag="CreationTime" Click="GridViewColumnHeader_Click"/>
                                 </GridViewColumn.Header>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -234,6 +234,27 @@ namespace DamnSimpleFileManager
             UpdateOperationsAvailability();
         }
 
+        private void List_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (sender is not ListView listView || listView.View is not GridView gridView || gridView.Columns.Count == 0)
+            {
+                return;
+            }
+
+            listView.UpdateLayout();
+            double otherColumnsWidth = 0;
+            for (int i = 0; i < gridView.Columns.Count - 1; i++)
+            {
+                otherColumnsWidth += gridView.Columns[i].ActualWidth;
+            }
+
+            double availableWidth = listView.ActualWidth - otherColumnsWidth - SystemParameters.VerticalScrollBarWidth - 2;
+            if (availableWidth > 0)
+            {
+                gridView.Columns[gridView.Columns.Count - 1].Width = availableWidth;
+            }
+        }
+
         private void List_DoubleClick(object sender, MouseButtonEventArgs e)
         {
             Logger.Log("List double-clicked");


### PR DESCRIPTION
## Summary
- make file list columns resize so the Created column expands to fill remaining space.
- add List_SizeChanged handler to adjust last GridViewColumn widths.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e172fabec8322ad750e6bf53d2448