### PR TITLE
Default sort by file type

### DIFF
--- a/Models/FilePaneViewModel.cs
+++ b/Models/FilePaneViewModel.cs
@@ -21,7 +21,7 @@ namespace DamnSimpleFileManager
             CreationTime
         }
 
-        private SortField currentSortField = SortField.Name;
+        private SortField currentSortField = SortField.Type;
         private bool sortAscending = true;
 
         private string? selectedDrive;


### PR DESCRIPTION
## Summary
- Change initial sorting field to file type so directory listings default to grouping by type

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1a38b93c8322a24287952304e82c