### PR TITLE
Add async copy/move operations with progress UI

### DIFF
--- a/Windows/CopyProgressWindow.xaml
+++ b/Windows/CopyProgressWindow.xaml
@@ -1,0 +1,12 @@
+<Window x:Class="DamnSimpleFileManager.Windows.CopyProgressWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Progress" Height="100" Width="300"
+        WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+    <Grid Margin="10">
+        <StackPanel>
+            <ProgressBar x:Name="ProgressBar" Height="20" Minimum="0" Maximum="100" Margin="0,0,0,10"/>
+            <Button Content="Cancel" Width="80" Height="25" HorizontalAlignment="Center" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Windows/CopyProgressWindow.xaml.cs
+++ b/Windows/CopyProgressWindow.xaml.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Windows;
+
+namespace DamnSimpleFileManager.Windows
+{
+    public partial class CopyProgressWindow : Window
+    {
+        public IProgress<double> Progress { get; }
+        public CancellationTokenSource Cancellation { get; } = new();
+
+        public CopyProgressWindow()
+        {
+            InitializeComponent();
+            Progress = new Progress<double>(v => ProgressBar.Value = v);
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            Cancellation.Cancel();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add CopyProgressWindow with progress bar and cancel support
- refactor FileOperationsService.Copy and Move into async methods with progress and cancellation
- invoke progress window from MainWindow during copy/move operations

## Testing
- ⚠️ `dotnet build` *(dotnet not installed)*
- ⚠️ `apt-get update` *(403 from repository)*

------
https://chatgpt.com/codex/tasks/task_e_689e538565408322bb122d4b26cbdc28