### PR TITLE
Remove ref parameter from asynchronous copy method

### DIFF
--- a/Services/FileOperationsService.cs
+++ b/Services/FileOperationsService.cs
@@ -49,7 +49,7 @@ namespace DamnSimpleFileManager.Services
                             continue;
                     }
 
-                    await CopyItemAsync(item, target, progress, token, totalBytes, ref copied);
+                    copied = await CopyItemAsync(item, target, progress, token, totalBytes, copied);
                     dest.LoadDirectory(dest.CurrentDir);
                 }
                 catch (OperationCanceledException)
@@ -122,7 +122,7 @@ namespace DamnSimpleFileManager.Services
                     }
                     catch (IOException)
                     {
-                        await CopyItemAsync(item, target, progress, token, totalBytes, ref copied);
+                        copied = await CopyItemAsync(item, target, progress, token, totalBytes, copied);
                         if (item is FileInfo)
                             File.Delete(item.FullName);
                         else if (item is DirectoryInfo)
@@ -249,7 +249,7 @@ namespace DamnSimpleFileManager.Services
             return 0;
         }
 
-        private static async Task CopyItemAsync(FileSystemInfo source, string destination, IProgress<double> progress, CancellationToken token, long totalBytes, ref long copied)
+        private static async Task<long> CopyItemAsync(FileSystemInfo source, string destination, IProgress<double> progress, CancellationToken token, long totalBytes, long copied)
         {
             if (source is FileInfo file)
             {
@@ -282,9 +282,10 @@ namespace DamnSimpleFileManager.Services
                 foreach (var child in dir.GetFileSystemInfos())
                 {
                     var childDest = Path.Combine(destination, child.Name);
-                    await CopyItemAsync(child, childDest, progress, token, totalBytes, ref copied);
+                    copied = await CopyItemAsync(child, childDest, progress, token, totalBytes, copied);
                 }
             }
+            return copied;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Avoid `ref` parameters in async operations by returning the updated byte count from `CopyItemAsync`.
- Update copy and move workflows to use the new return value.

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689e559a8fe88322870ceabb22084524