### PR TITLE
Display progress only after confirmation

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -418,11 +419,30 @@ namespace DamnSimpleFileManager
         {
             Logger.Log("Copy clicked");
             var items = ActiveList.SelectedItems.Cast<FileSystemInfo>().Where(i => i is not ParentDirectoryInfo).ToList();
+            if (Settings.CopyConfirmation)
+            {
+                var confirmed = new List<FileSystemInfo>();
+                foreach (var item in items)
+                {
+                    string target = Path.Combine(InactivePane.CurrentDir.FullName, item.Name);
+                    var result = MessageBox.Show(this,
+                        Localization.Get("Confirm_Copy", item.FullName, target),
+                        Localization.Get("Confirm_Copy_Title"),
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Question);
+                    if (result == MessageBoxResult.Yes)
+                        confirmed.Add(item);
+                }
+                items = confirmed;
+            }
+            if (items.Count == 0)
+                return;
+
             var progressWindow = new CopyProgressWindow { Owner = this };
             progressWindow.Show();
             try
             {
-                await fileOperationsService.Copy(ActivePane, InactivePane, items, this, progressWindow.Progress, progressWindow.Cancellation.Token);
+                await fileOperationsService.Copy(ActivePane, InactivePane, items, this, progressWindow.Progress, progressWindow.Cancellation.Token, confirm: false);
             }
             catch (OperationCanceledException)
             {
@@ -438,11 +458,30 @@ namespace DamnSimpleFileManager
         {
             Logger.Log("Move clicked");
             var items = ActiveList.SelectedItems.Cast<FileSystemInfo>().Where(i => i is not ParentDirectoryInfo).ToList();
+            if (Settings.MoveConfirmation)
+            {
+                var confirmed = new List<FileSystemInfo>();
+                foreach (var item in items)
+                {
+                    string target = Path.Combine(InactivePane.CurrentDir.FullName, item.Name);
+                    var result = MessageBox.Show(this,
+                        Localization.Get("Confirm_Move", item.FullName, target),
+                        Localization.Get("Confirm_Move_Title"),
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Question);
+                    if (result == MessageBoxResult.Yes)
+                        confirmed.Add(item);
+                }
+                items = confirmed;
+            }
+            if (items.Count == 0)
+                return;
+
             var progressWindow = new CopyProgressWindow { Owner = this };
             progressWindow.Show();
             try
             {
-                await fileOperationsService.Move(ActivePane, InactivePane, items, this, progressWindow.Progress, progressWindow.Cancellation.Token);
+                await fileOperationsService.Move(ActivePane, InactivePane, items, this, progressWindow.Progress, progressWindow.Cancellation.Token, confirm: false);
             }
             catch (OperationCanceledException)
             {

--- a/Services/FileOperationsService.cs
+++ b/Services/FileOperationsService.cs
@@ -12,7 +12,7 @@ namespace DamnSimpleFileManager.Services
 {
     internal class FileOperationsService
     {
-        public async Task Copy(FilePaneViewModel source, FilePaneViewModel dest, IEnumerable<FileSystemInfo> items, Window owner, IProgress<double> progress, CancellationToken token)
+        public async Task Copy(FilePaneViewModel source, FilePaneViewModel dest, IEnumerable<FileSystemInfo> items, Window owner, IProgress<double> progress, CancellationToken token, bool confirm = true)
         {
             var selectedItems = items.Where(i => i is not ParentDirectoryInfo).ToList();
             if (selectedItems.Count == 0)
@@ -37,7 +37,7 @@ namespace DamnSimpleFileManager.Services
                 Logger.Log($"Copying '{item.FullName}' to '{target}'");
                 try
                 {
-                    if (Settings.CopyConfirmation)
+                    if (confirm && Settings.CopyConfirmation)
                     {
                         var result = MessageBox.Show(
                             owner,
@@ -68,7 +68,7 @@ namespace DamnSimpleFileManager.Services
             }
         }
 
-        public async Task Move(FilePaneViewModel source, FilePaneViewModel dest, IEnumerable<FileSystemInfo> items, Window owner, IProgress<double> progress, CancellationToken token)
+        public async Task Move(FilePaneViewModel source, FilePaneViewModel dest, IEnumerable<FileSystemInfo> items, Window owner, IProgress<double> progress, CancellationToken token, bool confirm = true)
         {
             var selectedItems = items.Where(i => i is not ParentDirectoryInfo).ToList();
             if (selectedItems.Count == 0)
@@ -93,7 +93,7 @@ namespace DamnSimpleFileManager.Services
                 Logger.Log($"Moving '{item.FullName}' to '{target}'");
                 try
                 {
-                    if (Settings.MoveConfirmation)
+                    if (confirm && Settings.MoveConfirmation)
                     {
                         var result = MessageBox.Show(
                             owner,


### PR DESCRIPTION
## Summary
- Avoid showing copy/move progress window until after the user confirms the operation.
- Allow FileOperationsService.Copy/Move to skip confirmations when already handled.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e56ee77548322a71eacffb502e426