### PR TITLE
Ensure copy progress dialog shows Cancel button fully

### DIFF
--- a/Windows/CopyProgressWindow.xaml
+++ b/Windows/CopyProgressWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="DamnSimpleFileManager.Windows.CopyProgressWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Progress" Height="100" Width="300"
+        Title="Progress" Width="300"
+        SizeToContent="Height"
         WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
     <Grid Margin="10">
         <StackPanel>


### PR DESCRIPTION
## Summary
- Resize copy/move progress window to fit its content so the Cancel button is fully visible

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e5899e248832288600835087e6155