### PR TITLE
Fix Alt+F1/F2 shortcuts and document rename

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -285,12 +285,12 @@ namespace DamnSimpleFileManager
                     LeftList.Focus();
                 e.Handled = true;
             }
-            else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt) && e.Key == Key.F1)
+            else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt) && e.SystemKey == Key.F1)
             {
                 LeftList.Focus();
                 e.Handled = true;
             }
-            else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt) && e.Key == Key.F2)
+            else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt) && e.SystemKey == Key.F2)
             {
                 RightList.Focus();
                 e.Handled = true;

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Set `move_confirmation=false` to move files and folders without confirmation.
 
 - **Alt+F1** – Switch focus to the left pane
 - **Alt+F2** – Switch focus to the right pane
+- **F2** – Rename selected files or folders
 - **F5** – Copy selected files or folders to the opposite pane
 - **F6** – Move selected files or folders to the opposite pane
 - **F7** – Create a new folder


### PR DESCRIPTION
## Summary
- handle Alt+F1 and Alt+F2 using `SystemKey` so pane switching works
- document F2 rename shortcut in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e66c883788322a3f8c0506be239c2