### PR TITLE
Enable Alt+F1/F2 drive dropdown shortcuts

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -287,12 +287,14 @@ namespace DamnSimpleFileManager
             }
             else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt) && e.SystemKey == Key.F1)
             {
-                LeftList.Focus();
+                LeftDriveSelector.Focus();
+                LeftDriveSelector.IsDropDownOpen = true;
                 e.Handled = true;
             }
             else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt) && e.SystemKey == Key.F2)
             {
-                RightList.Focus();
+                RightDriveSelector.Focus();
+                RightDriveSelector.IsDropDownOpen = true;
                 e.Handled = true;
             }
             else if (e.Key == Key.F2)

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Set `move_confirmation=false` to move files and folders without confirmation.
 
 ## Keyboard Shortcuts
 
-- **Alt+F1** – Switch focus to the left pane
-- **Alt+F2** – Switch focus to the right pane
+- **Alt+F1** – Open drive selection for the left pane
+- **Alt+F2** – Open drive selection for the right pane
 - **F2** – Rename selected files or folders
 - **F5** – Copy selected files or folders to the opposite pane
 - **F6** – Move selected files or folders to the opposite pane


### PR DESCRIPTION
## Summary
- Make Alt+F1 and Alt+F2 open drive selectors for left and right panes
- Document new shortcuts in README

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e682ceacc83228e5e9b19b5c98fe3