### PR TITLE
Remove Alt-F1 and Alt-F2 shortcuts

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -285,18 +285,6 @@ namespace DamnSimpleFileManager
                     LeftList.Focus();
                 e.Handled = true;
             }
-            else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt) && e.SystemKey == Key.F1)
-            {
-                LeftDriveSelector.Focus();
-                LeftDriveSelector.IsDropDownOpen = true;
-                e.Handled = true;
-            }
-            else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt) && e.SystemKey == Key.F2)
-            {
-                RightDriveSelector.Focus();
-                RightDriveSelector.IsDropDownOpen = true;
-                e.Handled = true;
-            }
             else if (e.Key == Key.F2)
             {
                 RenameSelected();

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Set `move_confirmation=false` to move files and folders without confirmation.
 
 ## Keyboard Shortcuts
 
-- **Alt+F1** – Open drive selection for the left pane
-- **Alt+F2** – Open drive selection for the right pane
 - **F2** – Rename selected files or folders
 - **F5** – Copy selected files or folders to the opposite pane
 - **F6** – Move selected files or folders to the opposite pane


### PR DESCRIPTION
## Summary
- remove Alt+F1 and Alt+F2 key handling from the main window
- update keyboard shortcut documentation to match removed hotkeys

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e693189448322abfa5f252c8ca696