### PR TITLE
feat: allow opening settings ini

### DIFF
--- a/Languages/English.lang
+++ b/Languages/English.lang
@@ -57,6 +57,7 @@ Menu_Services=_Services
 Menu_ControlPanel=Control _Panel
 Menu_System=_System
 Menu_Lynkr=_Lynkr
+Menu_OpenSettingsIni=_Open Settings ini file
 Column_Name=Name
 Column_Type=Type
 Column_Size=Size

--- a/Languages/Russian.lang
+++ b/Languages/Russian.lang
@@ -57,6 +57,7 @@ Menu_Services=_Службы
 Menu_ControlPanel=_Панель управления
 Menu_System=_Система
 Menu_Lynkr=_Lynkr
+Menu_OpenSettingsIni=_Открыть файл настроек ini
 Column_Name=Имя
 Column_Type=Тип
 Column_Size=Размер

--- a/Languages/Spanish.lang
+++ b/Languages/Spanish.lang
@@ -57,6 +57,7 @@ Menu_Services=_Servicios
 Menu_ControlPanel=_Panel de control
 Menu_System=_Sistema
 Menu_Lynkr=_Lynkr
+Menu_OpenSettingsIni=_Abrir archivo de configuración ini
 Column_Name=Nombre
 Column_Type=Tipo
 Column_Size=Tamaño

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -46,6 +46,7 @@
                 <MenuItem x:Name="ControlPanelMenuItem" Header="Control Panel" Click="OpenControlPanel_Click"/>
                 <MenuItem x:Name="SystemMenuItem" Header="System" Click="OpenSystem_Click"/>
                 <MenuItem x:Name="LynkrMenuItem" Header="Lynkr" Click="OpenLynkr_Click"/>
+                <MenuItem x:Name="OpenSettingsIniMenuItem" Header="Open Settings ini file" Click="OpenSettingsIni_Click"/>
             </MenuItem>
             <MenuItem x:Name="HelpMenu" Header="_Help">
                 <MenuItem x:Name="AboutMenuItem" Header="_About" Click="About_Click"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -8,6 +8,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using Microsoft.Win32;
+using System.ComponentModel;
 using DamnSimpleFileManager.Services;
 using DamnSimpleFileManager.Windows;
 
@@ -79,6 +81,7 @@ namespace DamnSimpleFileManager
             ControlPanelMenuItem.Header = Localization.Get("Menu_ControlPanel");
             SystemMenuItem.Header = Localization.Get("Menu_System");
             LynkrMenuItem.Header = Localization.Get("Menu_Lynkr");
+            OpenSettingsIniMenuItem.Header = Localization.Get("Menu_OpenSettingsIni");
             ExitMenuItem.Header = Localization.Get("Menu_Exit");
             HelpMenu.Header = Localization.Get("Menu_Help");
             AboutMenuItem.Header = Localization.Get("Menu_About");
@@ -365,6 +368,38 @@ namespace DamnSimpleFileManager
                 Owner = this
             };
             wnd.ShowDialog();
+        }
+
+        private void OpenSettingsIni_Click(object sender, RoutedEventArgs e)
+        {
+            Logger.Log("Open Settings ini clicked");
+            var configPath = Path.Combine(AppContext.BaseDirectory, "dsfm.ini");
+            try
+            {
+                Process.Start(new ProcessStartInfo("notepad.exe", configPath)
+                {
+                    UseShellExecute = true
+                });
+            }
+            catch (Win32Exception)
+            {
+                var dialog = new OpenFileDialog
+                {
+                    Filter = "Executable Files (*.exe)|*.exe|All Files (*.*)|*.*"
+                };
+                if (dialog.ShowDialog() == true)
+                {
+                    Process.Start(new ProcessStartInfo(dialog.FileName, configPath)
+                    {
+                        UseShellExecute = true
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Error opening settings file", ex);
+                MessageBox.Show(this, Localization.Get("Error_OpenFile", ex.Message));
+            }
         }
 
         private void Exit_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- add Tools menu option to open dsfm.ini
- fallback to choose application if Notepad is unavailable
- localize new menu entry

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e6c14f86c8322a3b95e9b1a2c2d78