### PR TITLE
Show drive labels in drive selectors

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -8,6 +8,14 @@
         <local:FileTypeConverter x:Key="FileTypeConverter" />
         <local:FileForegroundConverter x:Key="FileForegroundConverter" />
         <local:FileSizeConverter x:Key="FileSizeConverter" />
+        <DataTemplate x:Key="DriveTemplate">
+            <TextBlock>
+                <Run Text="{Binding Name}" />
+                <Run Text=" [" />
+                <Run Text="{Binding VolumeLabel}" />
+                <Run Text="]" />
+            </TextBlock>
+        </DataTemplate>
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
@@ -60,10 +68,11 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <ComboBox x:Name="LeftDriveSelector" Grid.Column="0" Width="80"
+            <ComboBox x:Name="LeftDriveSelector" Grid.Column="0" Width="150"
                       HorizontalAlignment="Left"
                       ItemsSource="{Binding Drives, Mode=OneWay}"
-                      SelectedItem="{Binding SelectedDrive}"/>
+                      SelectedItem="{Binding SelectedDrive}"
+                      ItemTemplate="{StaticResource DriveTemplate}"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Center">
                 <Button x:Name="CreateFolderButton" Width="110" Height="30" Margin="0,0,5,0" Click="CreateFolder_Click">
                     <StackPanel Orientation="Horizontal">
@@ -108,10 +117,11 @@
                     </StackPanel>
                 </Button>
             </StackPanel>
-            <ComboBox x:Name="RightDriveSelector" Grid.Column="2" Width="80"
+            <ComboBox x:Name="RightDriveSelector" Grid.Column="2" Width="150"
                       HorizontalAlignment="Right"
                       ItemsSource="{Binding Drives, Mode=OneWay}"
-                      SelectedItem="{Binding SelectedDrive}"/>
+                      SelectedItem="{Binding SelectedDrive}"
+                      ItemTemplate="{StaticResource DriveTemplate}"/>
         </Grid>
 
         <!-- Кнопки Назад -->

--- a/Models/FilePaneViewModel.cs
+++ b/Models/FilePaneViewModel.cs
@@ -11,7 +11,7 @@ namespace DamnSimpleFileManager
     internal class FilePaneViewModel : INotifyPropertyChanged
     {
         public ObservableCollection<FileSystemInfo> Items { get; } = new();
-        public ObservableCollection<string> Drives { get; } = new();
+        public ObservableCollection<DriveInfo> Drives { get; } = new();
 
         internal enum SortField
         {
@@ -24,8 +24,8 @@ namespace DamnSimpleFileManager
         private SortField currentSortField = SortField.Type;
         private bool sortAscending = true;
 
-        private string? selectedDrive;
-        public string? SelectedDrive
+        private DriveInfo? selectedDrive;
+        public DriveInfo? SelectedDrive
         {
             get => selectedDrive;
             set
@@ -36,7 +36,7 @@ namespace DamnSimpleFileManager
                     OnPropertyChanged();
                     if (value != null)
                     {
-                        CurrentDir = new DirectoryInfo(value);
+                        CurrentDir = value.RootDirectory;
                         history.Clear();
                         LoadDirectory(CurrentDir);
                         OnPropertyChanged(nameof(CanGoBack));
@@ -125,11 +125,11 @@ namespace DamnSimpleFileManager
         public void PopulateDrives()
         {
             Drives.Clear();
-            foreach (var drive in System.IO.DriveInfo.GetDrives())
+            foreach (var drive in DriveInfo.GetDrives())
             {
                 if (drive.IsReady)
                 {
-                    Drives.Add(drive.Name);
+                    Drives.Add(drive);
                 }
             }
 
@@ -246,7 +246,7 @@ namespace DamnSimpleFileManager
 
         private void UpdateDriveInfo(DirectoryInfo dir)
         {
-            var drive = new System.IO.DriveInfo(dir.Root.FullName);
+            var drive = new DriveInfo(dir.Root.FullName);
             long total = drive.TotalSize;
             long free = drive.TotalFreeSpace;
             long used = total - free;


### PR DESCRIPTION
## Summary
- Display drive volume labels alongside drive letters in both left and right drive selectors
- Track drives as DriveInfo objects and load directories from their root directories

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f07ee2aa4832294d37e0afa4781c4