### PR TITLE
Improve drive selector spacing

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -68,7 +68,7 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <ComboBox x:Name="LeftDriveSelector" Grid.Column="0" Width="150"
+            <ComboBox x:Name="LeftDriveSelector" Grid.Column="0" Width="200" Margin="0,0,10,0"
                       HorizontalAlignment="Left"
                       ItemsSource="{Binding Drives, Mode=OneWay}"
                       SelectedItem="{Binding SelectedDrive}"
@@ -117,7 +117,7 @@
                     </StackPanel>
                 </Button>
             </StackPanel>
-            <ComboBox x:Name="RightDriveSelector" Grid.Column="2" Width="150"
+            <ComboBox x:Name="RightDriveSelector" Grid.Column="2" Width="200" Margin="10,0,0,0"
                       HorizontalAlignment="Right"
                       ItemsSource="{Binding Drives, Mode=OneWay}"
                       SelectedItem="{Binding SelectedDrive}"


### PR DESCRIPTION
## Summary
- Add horizontal margins around left and right drive selectors
- Widen drive selectors to accommodate drive labels

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fc09d8334832289274f7b17b16f9c