### PR TITLE
Expand main window width for drive labels

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:DamnSimpleFileManager"
-        Title="" Height="768" Width="1040"
+        Title="" Height="768" Width="1300"
         PreviewKeyDown="Window_PreviewKeyDown">
     <Window.Resources>
         <local:FileTypeConverter x:Key="FileTypeConverter" />


### PR DESCRIPTION
## Summary
- widen main window to provide more space for drive label display

## Testing
- `dotnet build` *(fails: command not found; attempted apt-get update but repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689fc1d06594832296829fad763effef