### PR TITLE
Enable double-click link opening in Lynkr

### DIFF
--- a/Windows/LynkrWindow.xaml
+++ b/Windows/LynkrWindow.xaml
@@ -18,7 +18,7 @@
                      GotFocus="TextBox_GotFocus" LostFocus="TextBox_LostFocus"/>
             <Button x:Name="AddButton" Content="Add" Width="60" Click="Add_Click"/>
         </StackPanel>
-        <ListView x:Name="LinksList" Grid.Row="1" Margin="0,0,0,10">
+        <ListView x:Name="LinksList" Grid.Row="1" Margin="0,0,0,10" MouseDoubleClick="LinksList_MouseDoubleClick">
             <ListView.View>
                 <GridView>
                     <GridViewColumn x:Name="UrlColumn" Header="Url" DisplayMemberBinding="{Binding Url}" Width="300"/>

--- a/Windows/LynkrWindow.xaml.cs
+++ b/Windows/LynkrWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Microsoft.Win32;
 using DamnSimpleFileManager.Utils;
 
@@ -75,6 +76,11 @@ namespace DamnSimpleFileManager.Windows
             {
                 linkManager.OpenLink(item.Url);
             }
+        }
+
+        private void LinksList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            Open_Click(sender, e);
         }
 
         private void Delete_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- open links on double click in Lynkr link manager

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a6561a088322ab31eb9fb05162d1