### PR TITLE
Close Lynkr window with Esc key

### DIFF
--- a/Windows/LynkrWindow.xaml
+++ b/Windows/LynkrWindow.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="" Height="400" Width="600"
-        WindowStartupLocation="CenterOwner">
+        WindowStartupLocation="CenterOwner"
+        PreviewKeyDown="Window_PreviewKeyDown">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/Windows/LynkrWindow.xaml.cs
+++ b/Windows/LynkrWindow.xaml.cs
@@ -105,10 +105,23 @@ namespace DamnSimpleFileManager.Windows
 
         private void Export_Click(object sender, RoutedEventArgs e)
         {
-            var dialog = new SaveFileDialog { Filter = $"{Localization.Get("Lynkr_JsonFilter")} (*.json)|*.json", FileName = "links.json" };
+            var dialog = new SaveFileDialog
+            {
+                Filter = $"{Localization.Get("Lynkr_JsonFilter")} (*.json)|*.json",
+                FileName = "links.json"
+            };
+
             if (dialog.ShowDialog() == true)
             {
                 linkManager.ExportToFile(dialog.FileName);
+            }
+        }
+
+        private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
             }
         }
     }


### PR DESCRIPTION
## Summary
- Allow Lynkr window to close when pressing the Escape key.
- Refactor SaveFileDialog initialization for clarity.

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a8bda7c4832280ca03ef7ac7a694