### PR TITLE
Preserve selection on navigation and disable hover highlight

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -16,6 +16,29 @@
                 <Run Text="]" />
             </TextBlock>
         </DataTemplate>
+        <Style TargetType="ListViewItem">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListViewItem">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
@@ -132,10 +155,12 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <Button x:Name="LeftBackButton" Grid.Column="0" Content="←" Width="40" Height="30"
-                    Command="{Binding NavigateBackCommand}" HorizontalAlignment="Left" Margin="5"/>
+                    Click="BackButton_Click" IsEnabled="{Binding CanGoBack}"
+                    HorizontalAlignment="Left" Margin="5"/>
             <Label Grid.Column="1" Width="10"/>
             <Button x:Name="RightBackButton" Grid.Column="2" Content="←" Width="40" Height="30"
-                    Command="{Binding NavigateBackCommand}" HorizontalAlignment="Right" Margin="5"/>
+                    Click="BackButton_Click" IsEnabled="{Binding CanGoBack}"
+                    HorizontalAlignment="Right" Margin="5"/>
         </Grid>
 
         <!-- Текущие пути -->

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -128,7 +128,15 @@ namespace DamnSimpleFileManager
                         try
                         {
                             Logger.Log($"Navigating into '{dir.FullName}'");
+                            pane.RememberSelection(dir.FullName, pane.CurrentDir.FullName);
                             pane.NavigateInto(dir);
+                            var last = pane.GetLastSelectedItem();
+                            if (last != null)
+                            {
+                                list.SelectedItem = last;
+                                list.ScrollIntoView(last);
+                            }
+                            list.Focus();
                         }
                         catch (Exception ex)
                         {
@@ -150,6 +158,13 @@ namespace DamnSimpleFileManager
                         {
                             Logger.Log($"Navigating into '{dir.FullName}'");
                             pane.NavigateInto(dir);
+                            var last = pane.GetLastSelectedItem();
+                            if (last != null)
+                            {
+                                list.SelectedItem = last;
+                                list.ScrollIntoView(last);
+                            }
+                            list.Focus();
                         }
                         catch (Exception ex)
                         {
@@ -271,6 +286,23 @@ namespace DamnSimpleFileManager
             var list = (ListView)sender;
             var pane = list == LeftList ? leftPane : rightPane;
             OpenSelected(pane, list);
+        }
+
+        private void BackButton_Click(object sender, RoutedEventArgs e)
+        {
+            Logger.Log("Back button clicked");
+            var pane = sender == LeftBackButton ? leftPane : rightPane;
+            var list = sender == LeftBackButton ? LeftList : RightList;
+            pane.NavigateBack();
+            var last = pane.GetLastSelectedItem();
+            if (last != null)
+            {
+                list.SelectedItem = last;
+                list.ScrollIntoView(last);
+            }
+            list.Focus();
+            activePane = pane;
+            UpdateOperationsAvailability();
         }
 
         private async void Window_PreviewKeyDown(object sender, KeyEventArgs e)

--- a/Models/FilePaneViewModel.cs
+++ b/Models/FilePaneViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -12,6 +13,7 @@ namespace DamnSimpleFileManager
     {
         public ObservableCollection<FileSystemInfo> Items { get; } = new();
         public ObservableCollection<DriveInfo> Drives { get; } = new();
+        private readonly Dictionary<string, string> lastSelectedItems = new();
 
         internal enum SortField
         {
@@ -281,11 +283,27 @@ namespace DamnSimpleFileManager
         {
             if (history.Count > 0)
             {
-                CurrentDir = history.Pop();
+                var previous = history.Pop();
+                lastSelectedItems[previous.FullName] = CurrentDir.FullName;
+                CurrentDir = previous;
                 LoadDirectory(CurrentDir);
                 OnPropertyChanged(nameof(CanGoBack));
                 NavigateBackCommand.RaiseCanExecuteChanged();
             }
+        }
+
+        public void RememberSelection(string directory, string selectedPath)
+        {
+            lastSelectedItems[directory] = selectedPath;
+        }
+
+        public FileSystemInfo? GetLastSelectedItem()
+        {
+            if (lastSelectedItems.TryGetValue(CurrentDir.FullName, out var path))
+            {
+                return Items.FirstOrDefault(i => i.FullName == path);
+            }
+            return null;
         }
 
         protected void OnPropertyChanged([CallerMemberName] string? name = null)


### PR DESCRIPTION
## Summary
- remove hover-based highlighting and only style selected items
- remember last selection per directory so navigating back or up keeps folders highlighted
- wire back buttons through code-behind to restore previous selection

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f1aa275083228d314354e0f927cb