### PR TITLE
Target .NET 8 for compatibility

### DIFF
--- a/FileManager.csproj
+++ b/FileManager.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <OutputType>WinExe</OutputType>
-      <TargetFramework>net9.0-windows</TargetFramework>
+      <TargetFramework>net8.0-windows</TargetFramework>
       <Nullable>enable</Nullable>
       <ImplicitUsings>enable</ImplicitUsings>
       <UseWPF>true</UseWPF>


### PR DESCRIPTION
## Summary
- target .NET 8 instead of 9 so WPF components like InitializeComponent are generated correctly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a204b7a20083229b5ad49814e6773a