### PR TITLE
Handle missing convert-back operations

### DIFF
--- a/Utils/FileForegroundConverter.cs
+++ b/Utils/FileForegroundConverter.cs
@@ -23,7 +23,7 @@ namespace DamnSimpleFileManager
 
         public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }

--- a/Utils/FileSizeConverter.cs
+++ b/Utils/FileSizeConverter.cs
@@ -17,7 +17,7 @@ namespace DamnSimpleFileManager
                 double sizeInMb = fi.Length / (1024.0 * 1024.0);
                 if (sizeInMb >= 1024)
                 {
-                    return $"{sizeInMb / 1024:0.##} GB";
+                    return $"{sizeInMb / 1024:0.##} GB"; 
                 }
                 return $"{sizeInMb:0.##} MB";
             }
@@ -26,7 +26,7 @@ namespace DamnSimpleFileManager
 
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }

--- a/Utils/FileTypeConverter.cs
+++ b/Utils/FileTypeConverter.cs
@@ -25,7 +25,7 @@ namespace DamnSimpleFileManager
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Prevent WPF value converters from throwing `NotImplementedException` by using `Binding.DoNothing` for convert-back

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a20688d4348322b105c406ea4c2849