### PR TITLE
Resolve FileSystem reference ambiguity

### DIFF
--- a/Services/FileOperationsService.cs
+++ b/Services/FileOperationsService.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.FileIO;
+using Interaction = Microsoft.VisualBasic.Interaction;
 using DamnSimpleFileManager;
 
 namespace DamnSimpleFileManager.Services


### PR DESCRIPTION
## Summary
- fix ambiguous FileSystem reference by removing Microsoft.VisualBasic namespace
- alias Interaction to preserve InputBox usage

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a248b8c4008322aa13740ce8f42bc3