### PR TITLE
Disable creation with empty names

### DIFF
--- a/Services/FileOperationsService.cs
+++ b/Services/FileOperationsService.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using Microsoft.VisualBasic.FileIO;
 using Interaction = Microsoft.VisualBasic.Interaction;
 using DamnSimpleFileManager;
+using DamnSimpleFileManager.Windows;
 
 namespace DamnSimpleFileManager.Services
 {
@@ -198,62 +199,72 @@ namespace DamnSimpleFileManager.Services
         public void CreateFolder(FilePaneViewModel pane, Window owner)
         {
             string path = pane.CurrentDir.FullName;
-            string name = Interaction.InputBox(
-                $"{Localization.Get("Prompt_FolderName")}\n{path}",
-                $"{Localization.Get("Prompt_CreateFolder")} - {path}",
-                Localization.Get("Default_FolderName"),
-                (int)(owner.Left + (owner.ActualWidth - 300) / 2),
-                (int)(owner.Top + (owner.ActualHeight - 150) / 2)).Trim();
-            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name, owner))
+            var dialog = new InputDialog
             {
-                string target = Path.Combine(path, name);
-                if (Directory.Exists(target))
+                Owner = owner,
+                Title = $"{Localization.Get("Prompt_CreateFolder")} - {path}"
+            };
+            dialog.Message = $"{Localization.Get("Prompt_FolderName")}\n{path}";
+            dialog.InputText = Localization.Get("Default_FolderName");
+            if (dialog.ShowDialog() == true)
+            {
+                string name = dialog.InputText.Trim();
+                if (!string.IsNullOrWhiteSpace(name) && ValidateName(name, owner))
                 {
-                    Logger.Log($"Folder already exists '{target}'");
-                    MessageBox.Show(owner, Localization.Get("Error_FolderExists", target), Localization.Get("Error_FolderExists_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
-                    return;
-                }
-                if (File.Exists(target))
-                {
-                    Logger.Log($"File already exists '{target}'");
-                    MessageBox.Show(owner, Localization.Get("Error_FileExists", target), Localization.Get("Error_FileExists_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
-                    return;
-                }
+                    string target = Path.Combine(path, name);
+                    if (Directory.Exists(target))
+                    {
+                        Logger.Log($"Folder already exists '{target}'");
+                        MessageBox.Show(owner, Localization.Get("Error_FolderExists", target), Localization.Get("Error_FolderExists_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
+                    if (File.Exists(target))
+                    {
+                        Logger.Log($"File already exists '{target}'");
+                        MessageBox.Show(owner, Localization.Get("Error_FileExists", target), Localization.Get("Error_FileExists_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
 
-                Directory.CreateDirectory(target);
-                Logger.Log($"Created folder '{name}' in '{path}'");
-                pane.LoadDirectory(pane.CurrentDir);
+                    Directory.CreateDirectory(target);
+                    Logger.Log($"Created folder '{name}' in '{path}'");
+                    pane.LoadDirectory(pane.CurrentDir);
+                }
             }
         }
 
         public void CreateFile(FilePaneViewModel pane, Window owner)
         {
             string path = pane.CurrentDir.FullName;
-            string name = Interaction.InputBox(
-                $"{Localization.Get("Prompt_FileName")}\n{path}",
-                $"{Localization.Get("Prompt_CreateFile")} - {path}",
-                Localization.Get("Default_FileName"),
-                (int)(owner.Left + (owner.ActualWidth - 300) / 2),
-                (int)(owner.Top + (owner.ActualHeight - 150) / 2)).Trim();
-            if (!string.IsNullOrWhiteSpace(name) && ValidateName(name, owner))
+            var dialog = new InputDialog
             {
-                string target = Path.Combine(path, name);
-                if (File.Exists(target))
+                Owner = owner,
+                Title = $"{Localization.Get("Prompt_CreateFile")} - {path}"
+            };
+            dialog.Message = $"{Localization.Get("Prompt_FileName")}\n{path}";
+            dialog.InputText = Localization.Get("Default_FileName");
+            if (dialog.ShowDialog() == true)
+            {
+                string name = dialog.InputText.Trim();
+                if (!string.IsNullOrWhiteSpace(name) && ValidateName(name, owner))
                 {
-                    Logger.Log($"File already exists '{target}'");
-                    MessageBox.Show(owner, Localization.Get("Error_FileExists", target), Localization.Get("Error_FileExists_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
-                    return;
-                }
-                if (Directory.Exists(target))
-                {
-                    Logger.Log($"Folder already exists '{target}'");
-                    MessageBox.Show(owner, Localization.Get("Error_FolderExists", target), Localization.Get("Error_FolderExists_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
-                    return;
-                }
+                    string target = Path.Combine(path, name);
+                    if (File.Exists(target))
+                    {
+                        Logger.Log($"File already exists '{target}'");
+                        MessageBox.Show(owner, Localization.Get("Error_FileExists", target), Localization.Get("Error_FileExists_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
+                    if (Directory.Exists(target))
+                    {
+                        Logger.Log($"Folder already exists '{target}'");
+                        MessageBox.Show(owner, Localization.Get("Error_FolderExists", target), Localization.Get("Error_FolderExists_Title"), MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
 
-                File.Create(target).Close();
-                Logger.Log($"Created file '{name}' in '{path}'");
-                pane.LoadDirectory(pane.CurrentDir);
+                    File.Create(target).Close();
+                    Logger.Log($"Created file '{name}' in '{path}'");
+                    pane.LoadDirectory(pane.CurrentDir);
+                }
             }
         }
 

--- a/Windows/InputDialog.xaml
+++ b/Windows/InputDialog.xaml
@@ -1,0 +1,18 @@
+<Window x:Class="DamnSimpleFileManager.Windows.InputDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="" Height="150" Width="400" WindowStartupLocation="CenterOwner">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBlock x:Name="MessageText" Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,10"/>
+        <TextBox x:Name="InputTextBox" Grid.Row="1" Margin="0,0,0,10" TextChanged="InputTextBox_TextChanged"/>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="OkButton" Content="OK" Width="75" Margin="0,0,5,0" Click="OkButton_Click" IsEnabled="False"/>
+            <Button Content="Cancel" Width="75" Click="CancelButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Windows/InputDialog.xaml.cs
+++ b/Windows/InputDialog.xaml.cs
@@ -1,0 +1,38 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace DamnSimpleFileManager.Windows;
+
+public partial class InputDialog : Window
+{
+    public InputDialog()
+    {
+        InitializeComponent();
+    }
+
+    public string InputText
+    {
+        get => InputTextBox.Text;
+        set => InputTextBox.Text = value;
+    }
+
+    public string Message
+    {
+        set => MessageText.Text = value;
+    }
+
+    private void OkButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+
+    private void InputTextBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        OkButton.IsEnabled = !string.IsNullOrWhiteSpace(InputTextBox.Text);
+    }
+}


### PR DESCRIPTION
## Summary
- add input dialog with disabled OK button when no name
- use new dialog for creating files and folders

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a25259ae348322984e374767861eba