### PR TITLE
Focus input dialog and close with Escape

### DIFF
--- a/Windows/InputDialog.xaml
+++ b/Windows/InputDialog.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="DamnSimpleFileManager.Windows.InputDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="" Height="150" Width="400" WindowStartupLocation="CenterOwner">
+        Title="" Height="150" Width="400" WindowStartupLocation="CenterOwner"
+        Loaded="Window_Loaded" PreviewKeyDown="Window_PreviewKeyDown">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/Windows/InputDialog.xaml.cs
+++ b/Windows/InputDialog.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace DamnSimpleFileManager.Windows;
 
@@ -34,5 +35,19 @@ public partial class InputDialog : Window
     private void InputTextBox_TextChanged(object sender, TextChangedEventArgs e)
     {
         OkButton.IsEnabled = !string.IsNullOrWhiteSpace(InputTextBox.Text);
+    }
+
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        InputTextBox.Focus();
+    }
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            DialogResult = false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Ensure input dialog focuses the text box when opened
- Allow closing the dialog with the Escape key

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a254126d7c8322a2cc9c3fb406e9a4