### PR TITLE
Select default text after focusing input dialog

### DIFF
--- a/Windows/InputDialog.xaml.cs
+++ b/Windows/InputDialog.xaml.cs
@@ -40,6 +40,7 @@ public partial class InputDialog : Window
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
         InputTextBox.Focus();
+        InputTextBox.SelectAll();
     }
 
     private void Window_PreviewKeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
## Summary
- Select all default text in create file/folder dialog's input box when the dialog loads

## Testing
- ❌ `dotnet build` *(dotnet not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68a2558833608322876b8b262ac42eed