### PR TITLE
Handle missing directories when navigating back

### DIFF
--- a/Models/FilePaneViewModel.cs
+++ b/Models/FilePaneViewModel.cs
@@ -220,6 +220,13 @@ namespace DamnSimpleFileManager
         private void SetupWatcher(DirectoryInfo dir)
         {
             watcher?.Dispose();
+
+            if (!dir.Exists)
+            {
+                watcher = null;
+                return;
+            }
+
             watcher = new FileSystemWatcher(dir.FullName)
             {
                 NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.LastWrite,
@@ -279,13 +286,19 @@ namespace DamnSimpleFileManager
 
         public void NavigateBack()
         {
-            if (history.Count > 0)
+            while (history.Count > 0)
             {
-                CurrentDir = history.Pop();
-                LoadDirectory(CurrentDir);
-                OnPropertyChanged(nameof(CanGoBack));
-                NavigateBackCommand.RaiseCanExecuteChanged();
+                var dir = history.Pop();
+                if (dir.Exists)
+                {
+                    CurrentDir = dir;
+                    LoadDirectory(CurrentDir);
+                    break;
+                }
             }
+
+            OnPropertyChanged(nameof(CanGoBack));
+            NavigateBackCommand.RaiseCanExecuteChanged();
         }
 
         protected void OnPropertyChanged([CallerMemberName] string? name = null)


### PR DESCRIPTION
## Summary
- Guard FileSystemWatcher setup when directory doesn't exist
- Skip removed directories in navigation history when pressing Back

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a25949176883229aa14d9e7b1fdd27