### PR TITLE
Harden settings loading

### DIFF
--- a/Models/Settings.cs
+++ b/Models/Settings.cs
@@ -8,43 +8,100 @@ namespace DamnSimpleFileManager
     {
         private static readonly string ConfigPath = Path.Combine(AppContext.BaseDirectory, "dsfm.ini");
         private static readonly Dictionary<string, string> Values = new();
+        private const long MaxConfigSizeBytes = 1 * 1024 * 1024;
 
         public static bool ShowHiddenFiles =>
-            Values.TryGetValue("hidden_files", out var value)
-                ? value.Equals("true", StringComparison.OrdinalIgnoreCase)
+            Values.TryGetValue("hidden_files", out var value) && bool.TryParse(value, out var result)
+                ? result
                 : true;
 
         public static bool CopyConfirmation =>
-            Values.TryGetValue("copy_confirmation", out var value)
-                ? value.Equals("true", StringComparison.OrdinalIgnoreCase)
+            Values.TryGetValue("copy_confirmation", out var value) && bool.TryParse(value, out var result)
+                ? result
                 : true;
 
         public static bool MoveConfirmation =>
-            Values.TryGetValue("move_confirmation", out var value)
-                ? value.Equals("true", StringComparison.OrdinalIgnoreCase)
+            Values.TryGetValue("move_confirmation", out var value) && bool.TryParse(value, out var result)
+                ? result
                 : true;
 
         public static bool RecycleBinDelete =>
-            Values.TryGetValue("recycle_bin_delete", out var value)
-                ? value.Equals("true", StringComparison.OrdinalIgnoreCase)
+            Values.TryGetValue("recycle_bin_delete", out var value) && bool.TryParse(value, out var result)
+                ? result
                 : true;
 
         public static void Load()
         {
+            var changed = false;
             Values.Clear();
-            if (File.Exists(ConfigPath))
+            try
             {
-                foreach (var line in File.ReadAllLines(ConfigPath))
+                if (File.Exists(ConfigPath))
                 {
-                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#") || line.StartsWith(";"))
-                        continue;
-                    var parts = line.Split('=', 2);
-                    if (parts.Length == 2)
-                        Values[parts[0].Trim().ToLowerInvariant()] = parts[1].Trim();
+                    var info = new FileInfo(ConfigPath);
+                    if (info.Length <= MaxConfigSizeBytes)
+                    {
+                        string[] lines = Array.Empty<string>();
+                        try
+                        {
+                            lines = File.ReadAllLines(ConfigPath);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogError("Error reading settings file", ex);
+                        }
+
+                        try
+                        {
+                            foreach (var line in lines)
+                            {
+                                if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#") || line.StartsWith(";"))
+                                    continue;
+
+                                var parts = line.Split('=', 2);
+                                if (parts.Length != 2)
+                                    continue;
+
+                                var key = parts[0].Trim().ToLowerInvariant();
+                                var val = parts[1].Trim();
+
+                                switch (key)
+                                {
+                                    case "hidden_files":
+                                    case "copy_confirmation":
+                                    case "move_confirmation":
+                                    case "recycle_bin_delete":
+                                        if (bool.TryParse(val, out var boolVal))
+                                            Values[key] = boolVal.ToString().ToLowerInvariant();
+                                        else
+                                        {
+                                            Logger.Log($"Invalid value for '{key}' in settings file");
+                                            changed = true;
+                                        }
+                                        break;
+                                    default:
+                                        Logger.Log($"Unknown setting '{key}' ignored");
+                                        changed = true;
+                                        break;
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogError("Error parsing settings file", ex);
+                        }
+                    }
+                    else
+                    {
+                        Logger.Log($"Settings file '{ConfigPath}' exceeds maximum size");
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                Logger.LogError("Error loading settings", ex);
+            }
 
-            var changed = false;
             if (!Values.ContainsKey("hidden_files"))
             {
                 Values["hidden_files"] = "true";


### PR DESCRIPTION
## Summary
- guard against oversized or malformed settings files
- parse booleans with `bool.TryParse` and ignore unknown keys
- log loading errors and fall back to defaults

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a25d4feda08322ab65ddc6e7fa3e83