### PR TITLE
Handle invalid or oversized link files safely

### DIFF
--- a/Utils/LinkStorage.cs
+++ b/Utils/LinkStorage.cs
@@ -1,18 +1,39 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using DamnSimpleFileManager;
 
 namespace DamnSimpleFileManager.Utils
 {
     public static class LinkStorage
     {
         private const string FileName = "links.json";
+        private const long MaxFileSizeBytes = 5 * 1024 * 1024;
 
         public static List<LinkItem> Load()
         {
             if (!File.Exists(FileName)) return new List<LinkItem>();
-            var json = File.ReadAllText(FileName);
-            return JsonSerializer.Deserialize<List<LinkItem>>(json) ?? new List<LinkItem>();
+            try
+            {
+                var fileInfo = new FileInfo(FileName);
+                if (fileInfo.Length > MaxFileSizeBytes)
+                {
+                    Logger.Log($"Links file '{FileName}' exceeds max size; returning empty list.");
+                    return new List<LinkItem>();
+                }
+
+                var json = File.ReadAllText(FileName);
+                return JsonSerializer.Deserialize<List<LinkItem>>(json) ?? new List<LinkItem>();
+            }
+            catch (IOException ex)
+            {
+                Logger.LogError($"Failed to read links file '{FileName}'", ex);
+            }
+            catch (JsonException ex)
+            {
+                Logger.LogError($"Failed to deserialize links file '{FileName}'", ex);
+            }
+            return new List<LinkItem>();
         }
 
         public static void Save(List<LinkItem> links)


### PR DESCRIPTION
## Summary
- guard link storage loading against IO errors, JSON errors, and oversized files
- validate import files before updating links and log any issues

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a25e5b4f008322829d4659bc5ec0d3