### PR TITLE
Open Task Manager from disk space status

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -298,7 +298,8 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <TextBlock x:Name="LeftSpaceText" Grid.Column="0" Margin="5,0">
+            <TextBlock x:Name="LeftSpaceText" Grid.Column="0" Margin="5,0"
+                       MouseLeftButtonDown="SpaceText_MouseLeftButtonDown">
                 <Run Text="{Binding TotalLabel, Mode=OneWay}" Foreground="Black"/>
                 <Run Text="{Binding TotalSpace, Mode=OneWay}" Foreground="Black"/>
                 <Run Text="  "/>
@@ -309,7 +310,8 @@
                 <Run Text="{Binding FreeSpace, Mode=OneWay}" Foreground="ForestGreen"/>
             </TextBlock>
             <Label Grid.Column="1" Width="10"/>
-            <TextBlock x:Name="RightSpaceText" Grid.Column="2" Margin="5,0" HorizontalAlignment="Right">
+            <TextBlock x:Name="RightSpaceText" Grid.Column="2" Margin="5,0" HorizontalAlignment="Right"
+                       MouseLeftButtonDown="SpaceText_MouseLeftButtonDown">
                 <Run Text="{Binding TotalLabel, Mode=OneWay}" Foreground="Black"/>
                 <Run Text="{Binding TotalSpace, Mode=OneWay}" Foreground="Black"/>
                 <Run Text="  "/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -429,6 +429,15 @@ namespace DamnSimpleFileManager
             about.ShowDialog();
         }
 
+        private void SpaceText_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ClickCount == 2)
+            {
+                Logger.Log("Disk space text double-clicked - opening Task Manager");
+                Process.Start(new ProcessStartInfo("taskmgr") { UseShellExecute = true });
+            }
+        }
+
         private void List_RightClick(object sender, MouseButtonEventArgs e)
         {
             Logger.Log("List right-clicked");


### PR DESCRIPTION
## Summary
- open Windows Task Manager when double-clicking the free/used/total disk space text

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bd4468788322b521da1a6b2f0a73