### PR TITLE
Expand bookmarks window width to fit button

### DIFF
--- a/Windows/FileBookmarksWindow.xaml
+++ b/Windows/FileBookmarksWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="DamnSimpleFileManager.Windows.FileBookmarksWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="" Height="400" Width="600"
+        Title="" Height="400" Width="750"
         WindowStartupLocation="CenterOwner"
         PreviewKeyDown="Window_PreviewKeyDown">
     <Grid Margin="10">


### PR DESCRIPTION
## Summary
- widen File Bookmarks window to accommodate 'Bookmark current dir' button

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a875aeabd883229e626c76584f3147