### PR TITLE
Handle invalid or oversized JSON link files

### DIFF
--- a/Utils/FileBookmarkStorage.cs
+++ b/Utils/FileBookmarkStorage.cs
@@ -7,12 +7,28 @@ namespace DamnSimpleFileManager.Utils
     public static class FileBookmarkStorage
     {
         private const string FileName = "file_bookmarks.json";
+        private const long MaxFileSizeBytes = 1 * 1024 * 1024; // 1 MB limit
 
         public static List<FileBookmarkItem> Load()
         {
-            if (!File.Exists(FileName)) return new List<FileBookmarkItem>();
-            var json = File.ReadAllText(FileName);
-            return JsonSerializer.Deserialize<List<FileBookmarkItem>>(json) ?? new List<FileBookmarkItem>();
+            try
+            {
+                if (!File.Exists(FileName)) return new List<FileBookmarkItem>();
+                var fileInfo = new FileInfo(FileName);
+                if (fileInfo.Length > MaxFileSizeBytes)
+                {
+                    Logger.LogError($"Bookmark file '{FileName}' exceeds maximum size", new IOException($"File size {fileInfo.Length} exceeds {MaxFileSizeBytes}"));
+                    return new List<FileBookmarkItem>();
+                }
+
+                var json = File.ReadAllText(FileName);
+                return JsonSerializer.Deserialize<List<FileBookmarkItem>>(json) ?? new List<FileBookmarkItem>();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Failed to load '{FileName}'", ex);
+                return new List<FileBookmarkItem>();
+            }
         }
 
         public static void Save(List<FileBookmarkItem> bookmarks)

--- a/Utils/LinkStorage.cs
+++ b/Utils/LinkStorage.cs
@@ -7,12 +7,28 @@ namespace DamnSimpleFileManager.Utils
     public static class LinkStorage
     {
         private const string FileName = "links.json";
+        private const long MaxFileSizeBytes = 1 * 1024 * 1024; // 1 MB limit
 
         public static List<LinkItem> Load()
         {
-            if (!File.Exists(FileName)) return new List<LinkItem>();
-            var json = File.ReadAllText(FileName);
-            return JsonSerializer.Deserialize<List<LinkItem>>(json) ?? new List<LinkItem>();
+            try
+            {
+                if (!File.Exists(FileName)) return new List<LinkItem>();
+                var fileInfo = new FileInfo(FileName);
+                if (fileInfo.Length > MaxFileSizeBytes)
+                {
+                    Logger.LogError($"Link file '{FileName}' exceeds maximum size", new IOException($"File size {fileInfo.Length} exceeds {MaxFileSizeBytes}"));
+                    return new List<LinkItem>();
+                }
+
+                var json = File.ReadAllText(FileName);
+                return JsonSerializer.Deserialize<List<LinkItem>>(json) ?? new List<LinkItem>();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Failed to load '{FileName}'", ex);
+                return new List<LinkItem>();
+            }
         }
 
         public static void Save(List<LinkItem> links)


### PR DESCRIPTION
## Summary
- Guard link storage against oversized or invalid `links.json`
- Prevent oversized or malformed `file_bookmarks.json` from crashing the app

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a877ac02208322824047ac1ec35b14