### PR TITLE
Add XAML vector icons and theme-aware button bindings

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -4,6 +4,10 @@
              xmlns:local="clr-namespace:DamnSimpleFileManager"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Icons.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -76,45 +76,45 @@
                       SelectedItem="{Binding SelectedDrive}"
                       ItemTemplate="{StaticResource DriveTemplate}"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Center">
-                <Button x:Name="CreateFolderButton" Width="110" Height="30" Margin="0,0,5,0" Click="CreateFolder_Click">
+                <Button x:Name="CreateFolderButton" Width="110" Height="30" Margin="0,0,5,0" Click="CreateFolder_Click" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="📁" Margin="0,0,5,0"/>
+                        <Path Data="{StaticResource FolderIcon}" Width="16" Height="16" Margin="0,0,5,0" Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" Stretch="Uniform" />
                         <TextBlock x:Name="CreateFolderText"/>
                     </StackPanel>
                 </Button>
-                <Button x:Name="CreateFileButton" Width="110" Height="30" Margin="0,0,5,0" Click="CreateFile_Click">
+                <Button x:Name="CreateFileButton" Width="110" Height="30" Margin="0,0,5,0" Click="CreateFile_Click" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="📄" Margin="0,0,5,0"/>
+                        <Path Data="{StaticResource FileIcon}" Width="16" Height="16" Margin="0,0,5,0" Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" Stretch="Uniform" />
                         <TextBlock x:Name="CreateFileText"/>
                     </StackPanel>
                 </Button>
-                <Button x:Name="ViewButton" Width="110" Height="30" Margin="0,0,5,0" Click="View_Click" IsEnabled="False">
+                <Button x:Name="ViewButton" Width="110" Height="30" Margin="0,0,5,0" Click="View_Click" IsEnabled="False" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="👁️" Margin="0,0,5,0"/>
+                        <Path Data="{StaticResource ViewIcon}" Width="16" Height="16" Margin="0,0,5,0" Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" Stretch="Uniform" />
                         <TextBlock x:Name="ViewText"/>
                     </StackPanel>
                 </Button>
-                <Button x:Name="CopyButton" Width="110" Height="30" Margin="0,0,5,0" Click="Copy_Click" IsEnabled="False">
+                <Button x:Name="CopyButton" Width="110" Height="30" Margin="0,0,5,0" Click="Copy_Click" IsEnabled="False" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="📋" Margin="0,0,5,0"/>
+                        <Path Data="{StaticResource CopyIcon}" Width="16" Height="16" Margin="0,0,5,0" Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" Stretch="Uniform" />
                         <TextBlock x:Name="CopyText"/>
                     </StackPanel>
                 </Button>
-                <Button x:Name="MoveButton" Width="110" Height="30" Margin="0,0,5,0" Click="Move_Click" IsEnabled="False">
+                <Button x:Name="MoveButton" Width="110" Height="30" Margin="0,0,5,0" Click="Move_Click" IsEnabled="False" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="📂" Margin="0,0,5,0"/>
+                        <Path Data="{StaticResource MoveIcon}" Width="16" Height="16" Margin="0,0,5,0" Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" Stretch="Uniform" />
                         <TextBlock x:Name="MoveText"/>
                     </StackPanel>
                 </Button>
-                <Button x:Name="DeleteButton" Width="110" Height="30" Margin="0,0,5,0" Click="Delete_Click" IsEnabled="False">
+                <Button x:Name="DeleteButton" Width="110" Height="30" Margin="0,0,5,0" Click="Delete_Click" IsEnabled="False" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="🗑️" Margin="0,0,5,0"/>
+                        <Path Data="{StaticResource DeleteIcon}" Width="16" Height="16" Margin="0,0,5,0" Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" Stretch="Uniform" />
                         <TextBlock x:Name="DeleteText"/>
                     </StackPanel>
                 </Button>
-                <Button x:Name="TerminalButton" Width="110" Height="30" Click="OpenTerminal_Click">
+                <Button x:Name="TerminalButton" Width="110" Height="30" Click="OpenTerminal_Click" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="💻" Margin="0,0,5,0"/>
+                        <Path Data="{StaticResource TerminalIcon}" Width="16" Height="16" Margin="0,0,5,0" Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" Stretch="Uniform" />
                         <TextBlock x:Name="TerminalText"/>
                     </StackPanel>
                 </Button>

--- a/Resources/Icons.xaml
+++ b/Resources/Icons.xaml
@@ -1,0 +1,22 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <PathGeometry x:Key="FolderIcon" Figures="M2,4 H6 L8,6 H14 V14 H2 Z" />
+    <PathGeometry x:Key="FileIcon" Figures="M3,2 H11 L13,4 V14 H3 Z M11,2 V4 H13" />
+    <GeometryGroup x:Key="ViewIcon" FillRule="EvenOdd">
+        <EllipseGeometry Center="8,8" RadiusX="7" RadiusY="5"/>
+        <EllipseGeometry Center="8,8" RadiusX="2" RadiusY="2"/>
+    </GeometryGroup>
+    <GeometryGroup x:Key="CopyIcon">
+        <RectangleGeometry Rect="5,4,8,8"/>
+        <RectangleGeometry Rect="3,6,8,8"/>
+    </GeometryGroup>
+    <PathGeometry x:Key="MoveIcon" Figures="M4,8 L10,4 V7 H14 V9 H10 V12 Z" />
+    <GeometryGroup x:Key="DeleteIcon">
+        <RectangleGeometry Rect="4,5,8,9"/>
+        <RectangleGeometry Rect="5,2,6,2"/>
+    </GeometryGroup>
+    <GeometryGroup x:Key="TerminalIcon">
+        <RectangleGeometry Rect="3,3,10,7"/>
+        <RectangleGeometry Rect="6,11,4,1"/>
+    </GeometryGroup>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- add geometry-based icon resources in a new Icons.xaml dictionary
- merge icon resources into the application
- replace emoji buttons with vector icons bound to theme brushes for hover/disabled state support

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f3cb04fc8322ac0ba8b655fbcf2a