### PR TITLE
feat: add dark theme support

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -10,8 +10,6 @@ namespace DamnSimpleFileManager
     {
         protected override void OnStartup(StartupEventArgs e)
         {
-            base.OnStartup(e);
-
             AppDomain.CurrentDomain.UnhandledException += (s, args) =>
             {
                 var ex = args.ExceptionObject as Exception ?? new Exception(args.ExceptionObject.ToString());
@@ -24,6 +22,16 @@ namespace DamnSimpleFileManager
             };
 
             Settings.Load();
+            if (Settings.DarkTheme)
+            {
+                Resources.MergedDictionaries.Add(new ResourceDictionary
+                {
+                    Source = new Uri("Resources/DarkTheme.xaml", UriKind.Relative)
+                });
+            }
+
+            base.OnStartup(e);
+
             Logger.Log("Application started");
         }
     }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -301,8 +301,8 @@
             </Grid.ColumnDefinitions>
             <TextBlock x:Name="LeftSpaceText" Grid.Column="0" Margin="5,0"
                        MouseLeftButtonDown="SpaceText_MouseLeftButtonDown">
-                <Run Text="{Binding TotalLabel, Mode=OneWay}" Foreground="Black"/>
-                <Run Text="{Binding TotalSpace, Mode=OneWay}" Foreground="Black"/>
+                <Run Text="{Binding TotalLabel, Mode=OneWay}" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+                <Run Text="{Binding TotalSpace, Mode=OneWay}" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
                 <Run Text="  "/>
                 <Run Text="{Binding UsedLabel, Mode=OneWay}" Foreground="DarkRed"/>
                 <Run Text="{Binding UsedSpace, Mode=OneWay}" Foreground="DarkRed"/>
@@ -313,8 +313,8 @@
             <Label Grid.Column="1" Width="10"/>
             <TextBlock x:Name="RightSpaceText" Grid.Column="2" Margin="5,0" HorizontalAlignment="Right"
                        MouseLeftButtonDown="SpaceText_MouseLeftButtonDown">
-                <Run Text="{Binding TotalLabel, Mode=OneWay}" Foreground="Black"/>
-                <Run Text="{Binding TotalSpace, Mode=OneWay}" Foreground="Black"/>
+                <Run Text="{Binding TotalLabel, Mode=OneWay}" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+                <Run Text="{Binding TotalSpace, Mode=OneWay}" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
                 <Run Text="  "/>
                 <Run Text="{Binding UsedLabel, Mode=OneWay}" Foreground="DarkRed"/>
                 <Run Text="{Binding UsedSpace, Mode=OneWay}" Foreground="DarkRed"/>

--- a/Models/Settings.cs
+++ b/Models/Settings.cs
@@ -30,6 +30,11 @@ namespace DamnSimpleFileManager
                 ? result
                 : true;
 
+        public static bool DarkTheme =>
+            Values.TryGetValue("dark_theme", out var value) && bool.TryParse(value, out var result)
+                ? result
+                : false;
+
         public static void Load()
         {
             var changed = false;
@@ -71,6 +76,7 @@ namespace DamnSimpleFileManager
                                     case "copy_confirmation":
                                     case "move_confirmation":
                                     case "recycle_bin_delete":
+                                    case "dark_theme":
                                         if (bool.TryParse(val, out var boolVal))
                                             Values[key] = boolVal.ToString().ToLowerInvariant();
                                         else
@@ -120,6 +126,11 @@ namespace DamnSimpleFileManager
             if (!Values.ContainsKey("recycle_bin_delete"))
             {
                 Values["recycle_bin_delete"] = "true";
+                changed = true;
+            }
+            if (!Values.ContainsKey("dark_theme"))
+            {
+                Values["dark_theme"] = "false";
                 changed = true;
             }
             if (changed)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Set `hidden_files=false` to hide files and folders marked as hidden.
 Set `copy_confirmation=false` to copy files and folders without confirmation.
 Set `move_confirmation=false` to move files and folders without confirmation.
 Set `recycle_bin_delete=false` to delete items permanently instead of using the Recycle Bin.
+Set `dark_theme=true` to enable the dark theme.
 
 ## Keyboard Shortcuts
 

--- a/Resources/DarkTheme.xaml
+++ b/Resources/DarkTheme.xaml
@@ -1,0 +1,11 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}" Color="#FF1E1E1E"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="#FF2D2D30"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="#FFF0F0F0"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.WindowTextBrushKey}" Color="#FFF0F0F0"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF007ACC"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.MenuBrushKey}" Color="#FF2D2D30"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.MenuTextBrushKey}" Color="#FFF0F0F0"/>
+</ResourceDictionary>

--- a/dsfm.ini
+++ b/dsfm.ini
@@ -2,3 +2,4 @@ hidden_files=true
 copy_confirmation=true
 move_confirmation=true
 recycle_bin_delete=true
+dark_theme=false


### PR DESCRIPTION
## Summary
- allow enabling a dark theme through new `dark_theme` setting
- load a resource dictionary to apply dark styling when the setting is true
- document `dark_theme` option and update defaults

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f5fc718c832285731483dce539bd