### PR TITLE
Improve dark theme readability

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -3,7 +3,9 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:DamnSimpleFileManager"
         Title="" Height="768" Width="1300"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+        Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
     <Window.Resources>
         <local:FileTypeConverter x:Key="FileTypeConverter" />
         <local:FileForegroundConverter x:Key="FileForegroundConverter" />

--- a/Resources/DarkTheme.xaml
+++ b/Resources/DarkTheme.xaml
@@ -8,4 +8,24 @@
     <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="{x:Static SystemColors.MenuBrushKey}" Color="#FF2D2D30"/>
     <SolidColorBrush x:Key="{x:Static SystemColors.MenuTextBrushKey}" Color="#FFF0F0F0"/>
+
+    <!-- Default control styles for dark theme -->
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    </Style>
+
+    <Style TargetType="GridViewColumnHeader">
+        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    </Style>
+
+    <Style TargetType="ListView">
+        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    </Style>
+
+    <Style TargetType="TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    </Style>
 </ResourceDictionary>

--- a/Utils/FileForegroundConverter.cs
+++ b/Utils/FileForegroundConverter.cs
@@ -16,7 +16,7 @@ namespace DamnSimpleFileManager
         {
             if (value is DirectoryInfo || value is ParentDirectoryInfo)
             {
-                return Brushes.DeepSkyBlue;
+                return Brushes.LightSkyBlue;
             }
             return SystemColors.ControlTextBrush;
         }


### PR DESCRIPTION
## Summary
- apply dark theme styles for buttons, headers, lists and text elements
- ensure main window uses dark foreground/background brushes
- lighten directory listing colour for better contrast

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f77cbe08832285913f04cfc7b08c