### PR TITLE
Use red button hover highlight in dark theme

### DIFF
--- a/Resources/DarkTheme.xaml
+++ b/Resources/DarkTheme.xaml
@@ -13,6 +13,11 @@
     <Style TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="Red"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style TargetType="GridViewColumnHeader">


### PR DESCRIPTION
## Summary
- Add IsMouseOver trigger to button style in DarkTheme.xaml to turn background red

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f934be9483229f243ac9877f0490