### PR TITLE
Make highlight color red in dark theme

### DIFF
--- a/Resources/DarkTheme.xaml
+++ b/Resources/DarkTheme.xaml
@@ -4,7 +4,7 @@
     <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="#FF2D2D30"/>
     <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="#FFF0F0F0"/>
     <SolidColorBrush x:Key="{x:Static SystemColors.WindowTextBrushKey}" Color="#FFF0F0F0"/>
-    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF007ACC"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Red"/>
     <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="{x:Static SystemColors.MenuBrushKey}" Color="#FF2D2D30"/>
     <SolidColorBrush x:Key="{x:Static SystemColors.MenuTextBrushKey}" Color="#FFF0F0F0"/>


### PR DESCRIPTION
## Summary
- make highlight color red in dark theme so selections stand out

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403; unable to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fa6db3b8832294b1d968b4ee290b