### PR TITLE
Fix dark mode drive selector and back button contrast

### DIFF
--- a/Resources/DarkTheme.xaml
+++ b/Resources/DarkTheme.xaml
@@ -13,11 +13,19 @@
     <Style TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        <Setter Property="BorderThickness" Value="1"/>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="Red"/>
             </Trigger>
         </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ComboBox">
+        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
     </Style>
 
     <Style TargetType="GridViewColumnHeader">


### PR DESCRIPTION
## Summary
- improve visibility of buttons in dark theme
- style drive selector combo boxes for better contrast

## Testing
- `dotnet build -c Release` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fb68c870832287fe1945f83bebc9