### PR TITLE
Use Shift+F2 for pane toggle

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -52,7 +52,7 @@
                 <MenuItem x:Name="ExitMenuItem" Header="E_xit" Click="Exit_Click"/>
             </MenuItem>
             <MenuItem x:Name="ToolsMenu" Header="_Tools">
-                <MenuItem x:Name="TogglePaneMenuItem" Header="Add second pane" Click="TogglePaneMenuItem_Click" InputGestureText="Alt+F2"/>
+                <MenuItem x:Name="TogglePaneMenuItem" Header="Add second pane" Click="TogglePaneMenuItem_Click" InputGestureText="Shift+F2"/>
                 <MenuItem x:Name="ServicesMenuItem" Header="Services" Click="OpenServices_Click"/>
                 <MenuItem x:Name="ControlPanelMenuItem" Header="Control Panel" Click="OpenControlPanel_Click"/>
                 <MenuItem x:Name="SystemMenuItem" Header="System" Click="OpenSystem_Click"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -82,7 +82,7 @@ namespace DamnSimpleFileManager
             OpenTerminalMenuItem.Header = Localization.Get("Menu_OpenTerminal");
             ToolsMenu.Header = Localization.Get("Menu_Tools");
             TogglePaneMenuItem.Header = Localization.Get(isRightPaneVisible ? "Menu_RemoveSecondPane" : "Menu_AddSecondPane");
-            TogglePaneMenuItem.InputGestureText = "Alt+F2";
+            TogglePaneMenuItem.InputGestureText = "Shift+F2";
             ServicesMenuItem.Header = Localization.Get("Menu_Services");
             ControlPanelMenuItem.Header = Localization.Get("Menu_ControlPanel");
             SystemMenuItem.Header = Localization.Get("Menu_System");
@@ -296,7 +296,7 @@ namespace DamnSimpleFileManager
                     LeftList.Focus();
                 e.Handled = true;
             }
-            else if (e.Key == Key.F2 && Keyboard.Modifiers.HasFlag(ModifierKeys.Alt))
+            else if (e.Key == Key.F2 && Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
             {
                 TogglePane();
                 e.Handled = true;

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Set `start_single_pane=true` to launch with a single pane.
 - **F7** – Create a new folder
 - **Shift+F7** – Create a new file
 - **F8** – Delete selected files or folders (with confirmation)
-- **Alt+F2** – Toggle second pane
+- **Shift+F2** – Toggle second pane
 
 ## Building
 


### PR DESCRIPTION
## Summary
- Change second pane toggle shortcut from Alt+F2 to Shift+F2 across XAML and code-behind.
- Document Shift+F2 shortcut in README.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a3bb333483228b06c1350fdcfd17